### PR TITLE
Store TableProxy, instead of Future to TableProxy

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 X.Y.Z (YYYY-MM-DD)
 ------------------
+* Optimise storage and passing of TableProxy objects (:pr:`46`)
 * Convert SAFE_TABLE_FUNCTOR from macro to template function (:pr:`45`)
 * Fix `export CIBW_TEST_SKIP` (:pr:`42`)
 


### PR DESCRIPTION
It's not necessary to store and continually unpack a Future to the `TableProxy`.