### PR TITLE
Generalise the opening and creation of Tables

### DIFF
--- a/arcae/arrow_tables.pyx
+++ b/arcae/arrow_tables.pyx
@@ -35,6 +35,7 @@ from arcae.casa_tables cimport (CCasaTable,
                                 CComplexDoubleType,
                                 CComplexFloatType,
                                 CServiceLocator,
+                                open_table,
                                 complex64,
                                 complex128,
                                 UINT_MAX)
@@ -88,7 +89,7 @@ cdef class Table:
         cdef string cfilename = tobytes(filename)
 
         with nogil:
-            self.c_table = GetResultValue(CCasaTable.Make(cfilename))
+            self.c_table = GetResultValue(open_table(cfilename))
 
     def to_arrow(self, unsigned int startrow=0, unsigned int nrow=UINT_MAX, columns: list[str] | str = None):
         cdef:

--- a/arcae/casa_tables.pxd
+++ b/arcae/casa_tables.pxd
@@ -26,11 +26,9 @@ cdef extern from "../cpp/configuration.h" namespace "arcae" nogil:
         vector[string] GetKeys" Configuration::GetKeys"()
         size_t Size" Configuration::Size"()
 
-
 cdef extern from "../cpp/safe_table_proxy.h" namespace "arcae" nogil:
     cdef cppclass CCasaTable" arcae::SafeTableProxy":
         @staticmethod
-        CResult[shared_ptr[CCasaTable]] Make" SafeTableProxy::Make"(const string & filename)
         CResult[bool] close" SafeTableProxy::close"()
 
         CResult[shared_ptr[CTable]] to_arrow " SafeTableProxy::to_arrow"(unsigned int startrow, unsigned int nrow, const vector[string] & columns)
@@ -38,6 +36,10 @@ cdef extern from "../cpp/safe_table_proxy.h" namespace "arcae" nogil:
         CResult[unsigned int] ncolumns " SafeTableProxy::ncolumns"()
         CResult[vector[string]] columns " SafeTableProxy::columns"()
         CResult[vector[shared_ptr[CCasaTable]]] partition " SafeTableProxy::partition"(const vector[string] & partition_columns, const vector[string] & sort_columns)
+
+cdef extern from "../cpp/table_factory.h" namespace "arcae" nogil:
+    cdef CResult[shared_ptr[CCasaTable]] open_table(const string & filename)
+
 
 cdef extern from "../cpp/complex_type.h" namespace "arcae" nogil:
     cdef cppclass CComplexType" arcae::ComplexType"(CExtensionType):

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -7,7 +7,8 @@ add_library(arcae SHARED
     complex_type.cpp
     configuration.cpp
     service_locator.cpp
-    safe_table_proxy.cpp)
+    safe_table_proxy.cpp
+    table_factory.cpp)
 
 target_link_directories(arcae PUBLIC ${PYARROW_LIBDIRS})
 target_link_libraries(arcae PkgConfig::casacore arrow)

--- a/cpp/table_factory.cpp
+++ b/cpp/table_factory.cpp
@@ -1,0 +1,36 @@
+#include "safe_table_proxy.h"
+#include "table_factory.h"
+
+#include <casacore/tables/Tables.h>
+#include <casacore/tables/Tables/TableProxy.h>
+#include <casacore/tables/Tables/TableLock.h>
+
+using ::arrow::Result;
+using ::arrow::Status;
+
+using ::casacore::TableProxy;
+using ::casacore::TableLock;
+using ::casacore::Table;
+using ::casacore::Record;
+
+namespace arcae {
+
+Result<std::shared_ptr<SafeTableProxy>> open_table(const std::string & filename) {
+    return SafeTableProxy::Make([&filename]() -> Result<std::shared_ptr<TableProxy>> {
+        Record record;
+        TableLock lock(TableLock::LockOption::AutoNoReadLocking);
+
+        record.define("option", "usernoread");
+        record.define("internal", lock.interval());
+        record.define("maxwait", casacore::Int(lock.maxWait()));
+
+        try {
+            return std::make_shared<TableProxy>(
+                filename, record, Table::TableOption::Old);
+        } catch(std::exception & e) {
+            return Status::Invalid(e.what());
+        }
+    });
+}
+
+} // namespace arcae

--- a/cpp/table_factory.h
+++ b/cpp/table_factory.h
@@ -1,0 +1,18 @@
+#ifndef ARCAE_TABLE_FACTORY_H
+#define ARCAE_TABLE_FACTORY_H
+
+#include <memory>
+#include <string>
+
+#include <arrow/result.h>
+
+#include "safe_table_proxy.h"
+
+namespace arcae {
+
+arrow::Result<std::shared_ptr<SafeTableProxy>> open_table(const std::string & filename);
+
+} // namespace arcae
+
+
+#endif // ARCAE_TABLE_FACTORY_H


### PR DESCRIPTION
Previously, `SafeTableProxy::Make` took a filename argument which would open a table for reading.

This has been generalised to take a functor, allowing opening/creation of TableProxy's by arbitrary methods.