### PR TITLE
Use vcpkg's internal github actions binary caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,12 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@v3
 
+      - name: Get Github Action Cache Variables
+        uses: actions/github-script@v6
+        with:
+          script: |
+            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
+            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
 
       - name: Run cibuildwheel
         uses: pypa/cibuildwheel@v2.13.1
@@ -81,8 +87,8 @@ jobs:
           CIBW_BUILD_FRONTEND: build
           CIBW_BEFORE_ALL_LINUX: yum install -y zip flex bison gcc-gfortran
           CIBW_ENVIRONMENT_LINUX: >
-            ACTIONS_CACHE_URL=${{ env.ACTIONS_CACHE_URL }}
-            ACTIONS_RUNTIME_TOKEN=${{ env.ACTIONS_RUNTIME_TOKEN }}
+            ACTIONS_CACHE_URL=$ACTIONS_CACHE_URL
+            ACTIONS_RUNTIME_TOKEN=$ACTIONS_RUNTIME_TOKEN
             VCPKG_BINARY_SOURCES="clear;x-gha,readwrite"
             VCPKG_TARGET_TRIPLET=${{ matrix.platform[2] }}
             VCPKG_INSTALLED_DIR=${{ env.VCPKG_INSTALLED_DIR }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,8 +81,8 @@ jobs:
           CIBW_BUILD_FRONTEND: build
           CIBW_BEFORE_ALL_LINUX: yum install -y zip flex bison gcc-gfortran
           CIBW_ENVIRONMENT_LINUX: >
-            ACTIONS_CACHE_URL=${{ process.env.ACTIONS_CACHE_URL }}
-            ACTIONS_RUNTIME_TOKEN=${{ process.env.ACTIONS_RUNTIME_TOKEN }}
+            ACTIONS_CACHE_URL=${{ env.ACTIONS_CACHE_URL }}
+            ACTIONS_RUNTIME_TOKEN=${{ env.ACTIONS_RUNTIME_TOKEN }}
             VCPKG_BINARY_SOURCES="clear;x-gha;readwrite"
             VCPKG_TARGET_TRIPLET=${{ matrix.platform[2] }}
             VCPKG_INSTALLED_DIR=${{ env.VCPKG_INSTALLED_DIR }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,6 @@ on:
     - cron: '30 2 * * 1,4' # Every Monday and Thursday @ 2h30am UTC
 
 env:
-  VCPKG_DEFAULT_BINARY_CACHE: /tmp/vcpkg-archives
   VCPKG_INSTALLED_DIR: /tmp/vcpkg_installed
   ARTIFACT_NAME: distribution
 
@@ -74,19 +73,6 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@v3
 
-      - name: Create VCPKG binary asset folder
-        run: mkdir -p ${{ env.VCPKG_DEFAULT_BINARY_CACHE }}
-
-      - name: Cache VCPKG binary assets
-        id: cache-vcpkg
-        uses: actions/cache@v3
-        with:
-          key: "vcpkg-cache-\
-            [${{ matrix.platform[0] }}]-\
-            [${{ matrix.platform[2] }}]-\
-            ${{ hashfiles('.env', 'vcpkg/manifest/vcpkg.json', 'vcpkg/overlay-ports/*', \
-                          format('vcpkg/overlay-triplets/{0}.cmake', matrix.platform[2])) }}"
-          path: ${{ env.VCPKG_DEFAULT_BINARY_CACHE }}
 
       - name: Run cibuildwheel
         uses: pypa/cibuildwheel@v2.13.1
@@ -95,7 +81,9 @@ jobs:
           CIBW_BUILD_FRONTEND: build
           CIBW_BEFORE_ALL_LINUX: yum install -y zip flex bison gcc-gfortran
           CIBW_ENVIRONMENT_LINUX: >
-            VCPKG_DEFAULT_BINARY_CACHE=/host/${{ env.VCPKG_DEFAULT_BINARY_CACHE }}
+            ACTIONS_CACHE_URL=${{ process.env.ACTIONS_CACHE_URL }}
+            ACTIONS_RUNTIME_TOKEN=${{ process.env.ACTIONS_RUNTIME_TOKEN }}
+            VCPKG_BINARY_SOURCES="clear;x-gha;readwrite"
             VCPKG_TARGET_TRIPLET=${{ matrix.platform[2] }}
             VCPKG_INSTALLED_DIR=${{ env.VCPKG_INSTALLED_DIR }}
             LD_LIBRARY_PATH=${{ env.VCPKG_INSTALLED_DIR }}/${{ matrix.platform[2] }}/lib

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
           CIBW_ENVIRONMENT_LINUX: >
             ACTIONS_CACHE_URL=${{ env.ACTIONS_CACHE_URL }}
             ACTIONS_RUNTIME_TOKEN=${{ env.ACTIONS_RUNTIME_TOKEN }}
-            VCPKG_BINARY_SOURCES="clear;x-gha;readwrite"
+            VCPKG_BINARY_SOURCES="clear;x-gha,readwrite"
             VCPKG_TARGET_TRIPLET=${{ matrix.platform[2] }}
             VCPKG_INSTALLED_DIR=${{ env.VCPKG_INSTALLED_DIR }}
             LD_LIBRARY_PATH=${{ env.VCPKG_INSTALLED_DIR }}/${{ matrix.platform[2] }}/lib

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,8 +87,8 @@ jobs:
           CIBW_BUILD_FRONTEND: build
           CIBW_BEFORE_ALL_LINUX: yum install -y zip flex bison gcc-gfortran
           CIBW_ENVIRONMENT_LINUX: >
-            ACTIONS_CACHE_URL=$ACTIONS_CACHE_URL
-            ACTIONS_RUNTIME_TOKEN=$ACTIONS_RUNTIME_TOKEN
+            ACTIONS_CACHE_URL=${{ env.ACTIONS_CACHE_URL }}
+            ACTIONS_RUNTIME_TOKEN=${{ env.ACTIONS_RUNTIME_TOKEN }}
             VCPKG_BINARY_SOURCES="clear;x-gha,readwrite"
             VCPKG_TARGET_TRIPLET=${{ matrix.platform[2] }}
             VCPKG_INSTALLED_DIR=${{ env.VCPKG_INSTALLED_DIR }}

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,7 @@ History
 X.Y.Z (YYYY-MM-DD)
 ------------------
 * Use ccache, if available (:pr:`50`)
+* Use vcpkg's internal github actions binary caching (:pr:`49`)
 * Generalise the opening and creation of Tables (:pr:`48`)
 * Optimise storage and passing of TableProxy objects (:pr:`46`)
 * Convert SAFE_TABLE_FUNCTOR from macro to template function (:pr:`45`)

--- a/remove-me.txt
+++ b/remove-me.txt
@@ -1,0 +1,1 @@
+Remove me

--- a/remove-me.txt
+++ b/remove-me.txt
@@ -1,1 +1,0 @@
-Remove me


### PR DESCRIPTION
Specifying a binary cache dir (`VCPKG_DEFAULT_BINARY_CACHE`) on the github action runner and caching it using github actions cache seems to not work after a period of time. See for e.g. this scheduled run: https://github.com/ratt-ru/arcae/actions/runs/5640211247

This PR uses vcpkg's internal github actions binary caching code.