### PR TITLE
Wrap a casacore::Table instead of a casacore::TableProxy

### DIFF
--- a/cpp/arcae/descriptor.cc
+++ b/cpp/arcae/descriptor.cc
@@ -20,9 +20,10 @@
 #include <casacore/casa/Containers/RecordInterface.h>
 #include <casacore/ms/MeasurementSets/MeasurementSet.h>
 #include <casacore/tables/Tables/TableError.h>
+#include <casacore/tables/Tables/TableProxy.h>
 #include <casacore/tables/Tables/TableRecord.h>
 #include <casacore/tables/Tables/TableDesc.h>
-#include <casacore/tables/Tables/TableProxy.h>
+#include <casacore/tables/Tables/Table.h>
 #include <casacore/casa/Containers/ValueHolder.h>
 
 #include "arcae/descriptor.h"
@@ -41,9 +42,10 @@ using ::casacore::TableDesc;
 using ::casacore::SetupNewTable;
 using ::casacore::Record;
 using ::casacore::RecordInterface;
-using ::casacore::TableProxy;
+using ::casacore::Table;
 using ::casacore::TableError;
 using ::casacore::Table;
+using ::casacore::TableProxy;
 
 using ::casacore::MeasurementSet;
 using ::casacore::MSAntenna;

--- a/cpp/arcae/safe_table_proxy.cc
+++ b/cpp/arcae/safe_table_proxy.cc
@@ -277,6 +277,7 @@ SafeTableProxy::Close() {
         return run_isolated([this]() -> Result<bool> {
             this->table_->flush();
             this->table_->unlock();
+            this->table_.reset();
             return true;
         });
     }

--- a/cpp/arcae/table_factory.cc
+++ b/cpp/arcae/table_factory.cc
@@ -18,7 +18,7 @@
 
 #include <casacore/tables/Tables/SetupNewTab.h>
 #include <casacore/tables/Tables.h>
-#include <casacore/tables/Tables/TableProxy.h>
+#include <casacore/tables/Tables/Table.h>
 #include <casacore/tables/Tables/TableLock.h>
 #include <casacore/ms/MeasurementSets/MeasurementSet.h>
 
@@ -30,7 +30,7 @@ using ::arrow::Status;
 using ::casacore::String;
 
 using ::casacore::SetupNewTable;
-using ::casacore::TableProxy;
+using ::casacore::Table;
 using ::casacore::TableLock;
 using ::casacore::Table;
 using ::casacore::Record;
@@ -81,17 +81,13 @@ static constexpr char kWeather[] = "WEATHER";
 } // namespace
 
 Result<std::shared_ptr<SafeTableProxy>> OpenTable(const std::string & filename) {
-    return SafeTableProxy::Make([&filename]() -> Result<std::shared_ptr<TableProxy>> {
-        Record record;
-        TableLock lock(TableLock::LockOption::AutoNoReadLocking);
+    return SafeTableProxy::Make([&filename]() -> Result<std::shared_ptr<Table>> {
+        auto table_lock = TableLock(TableLock::LockOption::NoLocking);
 
-        record.define("option", "usernoread");
-        record.define("internal", lock.interval());
-        record.define("maxwait", casacore::Int(lock.maxWait()));
 
         try {
-            return std::make_shared<TableProxy>(
-                filename, record, Table::TableOption::Old);
+            return std::make_shared<Table>(
+                filename, table_lock, Table::TableOption::Old);
         } catch(std::exception & e) {
             return Status::Invalid(e.what());
         }
@@ -121,47 +117,47 @@ Result<std::shared_ptr<SafeTableProxy>> DefaultMS(
                           DefaultMSFactory(modname, usubtable,
                                              json_table_desc, json_dminfo));
 
-    return SafeTableProxy::Make([&]() -> Result<std::shared_ptr<TableProxy>> {
+    return SafeTableProxy::Make([&]() -> Result<std::shared_ptr<Table>> {
         if(usubtable.empty() || usubtable == kMain) {
             auto ms = MeasurementSet(setup_new_table);
             // Create the MS default subtables
             ms.createDefaultSubtables(Table::New);
             // Create a table proxy
-            return std::make_shared<TableProxy>(ms);
+            return std::make_shared<Table>(ms);
         } else if(usubtable == kAntenna) {
-            return std::make_shared<TableProxy>(MSAntenna(setup_new_table));
+            return std::make_shared<Table>(MSAntenna(setup_new_table));
         } else if(usubtable == kDataDescription) {
-            return std::make_shared<TableProxy>(MSDataDescription(setup_new_table));
+            return std::make_shared<Table>(MSDataDescription(setup_new_table));
         } else if(usubtable == kDoppler) {
-            return std::make_shared<TableProxy>(MSDoppler(setup_new_table));
+            return std::make_shared<Table>(MSDoppler(setup_new_table));
         } else if(usubtable == kFeed) {
-            return std::make_shared<TableProxy>(MSFeed(setup_new_table));
+            return std::make_shared<Table>(MSFeed(setup_new_table));
         } else if(usubtable == kField) {
-            return std::make_shared<TableProxy>(MSField(setup_new_table));
+            return std::make_shared<Table>(MSField(setup_new_table));
         } else if(usubtable == kFlagCmd) {
-            return std::make_shared<TableProxy>(MSFlagCmd(setup_new_table));
+            return std::make_shared<Table>(MSFlagCmd(setup_new_table));
         } else if(usubtable == kFreqOffset) {
-            return std::make_shared<TableProxy>(MSFreqOffset(setup_new_table));
+            return std::make_shared<Table>(MSFreqOffset(setup_new_table));
         } else if(usubtable == kHistory) {
-            return std::make_shared<TableProxy>(MSHistory(setup_new_table));
+            return std::make_shared<Table>(MSHistory(setup_new_table));
         } else if(usubtable == kObservation) {
-            return std::make_shared<TableProxy>(MSObservation(setup_new_table));
+            return std::make_shared<Table>(MSObservation(setup_new_table));
         } else if(usubtable == kPointing) {
-            return std::make_shared<TableProxy>(MSPointing(setup_new_table));
+            return std::make_shared<Table>(MSPointing(setup_new_table));
         } else if(usubtable == kPolarization) {
-            return std::make_shared<TableProxy>(MSPolarization(setup_new_table));
+            return std::make_shared<Table>(MSPolarization(setup_new_table));
         } else if(usubtable == kProcessor) {
-            return std::make_shared<TableProxy>(MSProcessor(setup_new_table));
+            return std::make_shared<Table>(MSProcessor(setup_new_table));
         } else if(usubtable == kSource) {
-            return std::make_shared<TableProxy>(MSSource(setup_new_table));
+            return std::make_shared<Table>(MSSource(setup_new_table));
         } else if(usubtable == kSpectralWindow) {
-            return std::make_shared<TableProxy>(MSSpectralWindow(setup_new_table));
+            return std::make_shared<Table>(MSSpectralWindow(setup_new_table));
         } else if(usubtable == kState) {
-            return std::make_shared<TableProxy>(MSState(setup_new_table));
+            return std::make_shared<Table>(MSState(setup_new_table));
         } else if(usubtable == kSyscal) {
-            return std::make_shared<TableProxy>(MSSysCal(setup_new_table));
+            return std::make_shared<Table>(MSSysCal(setup_new_table));
         } else if(usubtable == kWeather) {
-            return std::make_shared<TableProxy>(MSWeather(setup_new_table));
+            return std::make_shared<Table>(MSWeather(setup_new_table));
         }
 
         return arrow::Status::Invalid("Uknown table type: ", usubtable);

--- a/cpp/tests/basic_test.cc
+++ b/cpp/tests/basic_test.cc
@@ -14,13 +14,12 @@ class BasicTableTests : public ::testing::Test {
     std::shared_ptr<arcae::SafeTableProxy> table_proxy_;
 
     void SetUp() override {
-      auto factory = []() -> arrow::Result<std::shared_ptr<casacore::TableProxy>> {
+      auto factory = []() -> arrow::Result<std::shared_ptr<casacore::Table>> {
         auto * test_info = ::testing::UnitTest::GetInstance()->current_test_info();
         auto table_desc = casacore::TableDesc(casacore::MeasurementSet::requiredTableDesc());
         auto table_name = std::string(test_info->name() + "-"s + arcae::hexuuid(4) + ".table"s);
         auto setup_new_table = casacore::SetupNewTable(table_name, table_desc, casacore::Table::New);
-        auto ms = casacore::MeasurementSet(setup_new_table, 100);
-        return std::make_shared<casacore::TableProxy>(ms);
+        return std::make_shared<casacore::MeasurementSet>(setup_new_table, 100);
       };
 
       ASSERT_OK_AND_ASSIGN(table_proxy_, arcae::SafeTableProxy::Make(factory));


### PR DESCRIPTION
Might be better to just deal with the lower-level interface.