### PR TITLE
Make export application dependencies optional

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,7 +151,7 @@ jobs:
             LD_LIBRARY_PATH=${{ env.VCPKG_INSTALLED_DIR }}/${{ matrix.platform[2] }}/lib
           CIBW_REPAIR_WHEEL_COMMAND_LINUX: >
             auditwheel repair -w {dest_dir} {wheel} --exclude libarrow_python.so --exclude libarrow.so.1400
-          CIBW_TEST_EXTRAS: test
+          CIBW_TEST_EXTRAS: applications,test
           CIBW_TEST_COMMAND: py.test -s -vvv --pyargs arcae
 
       - name: Upload wheel artifacts

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 X.Y.Z (YYYY-MM-DD)
 ------------------
+* Make export application dependencies optional (:pr:`80`)
 * Fix ENV access within cmake files (:pr:`79`)
 
 0.2.2 (2023-11-10)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,12 +14,14 @@ classifiers = [
 ]
 dependencies = [
     "appdirs",
-    "click",
-    "rich",
     "pyarrow == 14.0.1"
 ]
 
 [project.optional-dependencies]
+applications = [
+    "click",
+    "rich",
+]
 dev = [
     "black == 22.1.0",
     "flake8 == 4.0.1",

--- a/src/arcae/applications/entrypoint.py
+++ b/src/arcae/applications/entrypoint.py
@@ -1,4 +1,8 @@
-import click
+try:
+    import click
+except ImportError as e:
+    raise ImportError("click is not installed.\n"
+                      "pip install arcae[applications]") from e
 
 from arcae.applications.ms_export import MSExporter
 

--- a/src/arcae/applications/ms_export.py
+++ b/src/arcae/applications/ms_export.py
@@ -3,10 +3,14 @@ import os
 import os.path
 import shutil
 
-from rich.live import Live
-from rich.console import Group
-from rich.panel import Panel
-from rich.progress import Progress, SpinnerColumn, TimeElapsedColumn, TextColumn
+try:
+    from rich.live import Live
+    from rich.console import Group
+    from rich.panel import Panel
+    from rich.progress import Progress, SpinnerColumn, TimeElapsedColumn, TextColumn
+except ImportError as e:
+    raise ImportError("rich is not installed.\n"
+                      "pip install arcae[applications]")
 
 import arcae
 import pyarrow.parquet as pq


### PR DESCRIPTION
Don't depend on `rich` and `click` for the core library.