### PR TITLE
Export compile_commands.json by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,11 @@ set(CMAKE_JOB_POOL_COMPILE "compile")
 set(CMAKE_JOB_POOL_LINK "link")
 set(CMAKE_JOB_POOLS "compile=${ncores};link=2")
 
+# Export compile_commands.json by default
+if(NOT DEFINED CMAKE_EXPORT_COMPILE_COMMANDS)
+    set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+endif()
+
 find_program(CCACHE_FOUND ccache)
 if(CCACHE_FOUND)
     set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ccache)

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 X.Y.Z (YYYY-MM-DD)
 ------------------
+* Export compile_commands.json by default (:pr:`81`)
 * Make export application dependencies optional (:pr:`80`)
 * Fix ENV access within cmake files (:pr:`79`)
 


### PR DESCRIPTION
Useful for clangd tooling.