### PR TITLE
Upgrade to cibuildwheel 2.17

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,6 +1,6 @@
 build_and_store_wheels: &BUILD_AND_STORE_WHEELS
   install_cibuildwheel_script:
-    - python -m pip install cibuildwheel==2.16.5
+    - python -m pip install cibuildwheel==2.17
   run_cibuildwheel_script:
     - cibuildwheel
   wheels_artifacts:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,7 +168,7 @@ jobs:
         run: echo "CIBW_ENVIRONMENT_COMMON=$COMMON_ENV" >> $GITHUB_ENV
 
       - name: Run cibuildwheel
-        uses: pypa/cibuildwheel@v2.16.5
+        uses: pypa/cibuildwheel@v2.17
         env:
           CIBW_BUILD: ${{ matrix.cpython }}-${{ matrix.extra_build }}*
           CIBW_ARCHS: ${{ matrix.arch }}

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 X.Y.Z (YYYY-MM-DD)
 ------------------
+* Upgrade to cibuildwheel 2.17 (:pr:`83`)
 * Upgrade to pyarrow 15.0.0 (:pr:`76`)
 * Build linux arm64 and macos arm64/x86_64 wheels (:pr:`76`)
 * Upgrade vcpkg version to include wcslib 8.2.1 (:pr:`82`)


### PR DESCRIPTION
Mac 14 builds were failing due to a pipx-related issue

- https://github.com/ratt-ru/arcae/actions/runs/8548460675