### PR TITLE
Support table arguments in TAQL queries

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 X.Y.Z (YYYY-MM-DD)
 ------------------
+* Support Table arguments in TAQL queries (:pr:`93`)
 * Upgrade to pyarrow 16.0.0 (:pr:`92`)
 * Handle slice(None) in getcol index (:pr:`91`)
 

--- a/cpp/arcae/safe_table_proxy.h
+++ b/cpp/arcae/safe_table_proxy.h
@@ -1,7 +1,8 @@
 #ifndef ARCAE_SAFE_TABLE_PROXY_H
 #define ARCAE_SAFE_TABLE_PROXY_H
 
-#include <climits>
+// #include <climits>
+#include <cstddef>
 #include <functional>
 #include <type_traits>
 
@@ -12,6 +13,7 @@
 #include <arrow/util/thread_pool.h>
 
 #include "arcae/base_column_map.h"
+#include "arrow/status.h"
 
 namespace arcae {
 
@@ -26,6 +28,9 @@ private:
     std::shared_ptr<arrow::internal::ThreadPool> io_pool;
     bool is_closed;
 
+    friend arrow::Result<std::shared_ptr<SafeTableProxy>> Taql(
+            const std::string & taql,
+            const std::vector<std::shared_ptr<SafeTableProxy>> & tables);
 protected:
     SafeTableProxy() = default;
     SafeTableProxy(const SafeTableProxy & rhs) = delete;
@@ -75,10 +80,21 @@ public:
 
 
     template <typename Fn>
-    static arrow::Result<std::shared_ptr<SafeTableProxy>> Make(Fn && functor) {
+    static arrow::Result<std::shared_ptr<SafeTableProxy>> Make(
+            Fn && functor,
+            std::shared_ptr<arrow::internal::ThreadPool> io_pool=nullptr) {
         struct enable_make_shared_stp : public SafeTableProxy {};
         auto proxy = std::make_shared<enable_make_shared_stp>();
-        ARROW_ASSIGN_OR_RAISE(proxy->io_pool, ::arrow::internal::ThreadPool::Make(1));
+
+        if(io_pool) {
+            if(io_pool->GetCapacity() != 1) {
+                return arrow::Status::Invalid("Number of threads in supplied thread pool != 1");
+            }
+            proxy->io_pool = io_pool;
+        } else {
+            ARROW_ASSIGN_OR_RAISE(proxy->io_pool, ::arrow::internal::ThreadPool::Make(1));
+        }
+
 
         // Mark as closed so that if construction fails, we don't try to close it
         proxy->is_closed = true;

--- a/cpp/arcae/table_factory.h
+++ b/cpp/arcae/table_factory.h
@@ -20,7 +20,8 @@ arrow::Result<std::shared_ptr<SafeTableProxy>> DefaultMS(
                                 const std::string & json_table_desc="{}",
                                 const std::string & json_dminfo="{}");
 arrow::Result<std::shared_ptr<SafeTableProxy>> Taql(
-                                const std::string & taql);
+                                const std::string & taql,
+                                const std::vector<std::shared_ptr<SafeTableProxy>> & tables={});
 
 
 } // namespace arcae

--- a/src/arcae/arrow_tables.pxd
+++ b/src/arcae/arrow_tables.pxd
@@ -74,7 +74,8 @@ cdef extern from "arcae/table_factory.h" namespace "arcae" nogil:
                                                     const string & json_table_desc,
                                                     const string & json_dminfo)
     cdef CResult[shared_ptr[CCasaTable]] CTaql" arcae::Taql"(
-                                                    const string & taql)
+                                                    const string & taql,
+                                                    const vector[shared_ptr[CCasaTable]] & tables)
 
 
 cdef extern from "arcae/complex_type.h" namespace "arcae" nogil:


### PR DESCRIPTION
The tables must share the same underlying threadpool