### PR TITLE
Avoid creating ColumnDesc objects in inner loops

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 X.Y.Z (YYYY-MM-DD)
 ------------------
+* Avoid creating ColumnDesc objects in inner loops (:pr:`95`)
 * Support Table arguments in TAQL queries (:pr:`93`)
 * Upgrade to pyarrow 16.0.0 (:pr:`92`)
 * Handle slice(None) in getcol index (:pr:`91`)

--- a/cpp/arcae/column_read_map.cc
+++ b/cpp/arcae/column_read_map.cc
@@ -261,14 +261,16 @@ ShapeProvider::Make(const casacore::TableColumn & column,
                     const ColumnSelection & selection) {
 
   if(column.columnDesc().isFixedShape()) {
-    auto shape = column.columnDesc().shape();
+    auto column_desc = column.columnDesc();
+    auto shape = column_desc.shape();
     shape.append(casacore::IPosition({ssize_t(column.nrow())}));
     ARROW_RETURN_NOT_OK(CheckSelectionAgainstShape(shape, selection));
-    return ShapeProvider{std::cref(column), selection};
+    return ShapeProvider{column, selection, nullptr, std::size_t(column_desc.ndim()) + 1};
   }
 
   ARROW_ASSIGN_OR_RAISE(auto var_data, VariableShapeData::Make(column, selection));
-  return ShapeProvider{std::cref(column), std::cref(selection), std::move(var_data)};
+  auto ndim = var_data->nDim() + 1;
+  return ShapeProvider{column, selection, std::move(var_data), ndim};
 }
 
 // Returns the dimension size of this column

--- a/cpp/arcae/column_read_map.h
+++ b/cpp/arcae/column_read_map.h
@@ -44,6 +44,7 @@ struct ShapeProvider {
   std::reference_wrapper<const casacore::TableColumn> column_;
   std::reference_wrapper<const ColumnSelection> selection_;
   std::unique_ptr<VariableShapeData> var_data_;
+  std::size_t ndim_;
 
   static arrow::Result<ShapeProvider> Make(const casacore::TableColumn & column,
                                            const ColumnSelection & selection);
@@ -65,7 +66,7 @@ struct ShapeProvider {
 
   // Returns the number of dimensions, including row
   std::size_t nDim() const {
-    return (IsDefinitelyFixed() ? column_.get().columnDesc().ndim() : var_data_->nDim()) + 1;
+    return ndim_;
   }
 
   std::size_t RowDim() const { return nDim() - 1; }

--- a/cpp/arcae/column_write_map.cc
+++ b/cpp/arcae/column_write_map.cc
@@ -264,6 +264,7 @@ ArrowShapeProvider::Make(const casacore::TableColumn & column,
   ARROW_ASSIGN_OR_RAISE(auto properties, GetDataProperties(column, selection, data));
   return ArrowShapeProvider{std::cref(column),
                             std::cref(selection),
+                            column.columnDesc().isFixedShape(),
                             data,
                             std::move(properties.data_type),
                             std::move(properties.shape),

--- a/cpp/arcae/column_write_map.h
+++ b/cpp/arcae/column_write_map.h
@@ -29,6 +29,7 @@ namespace arcae {
 struct ArrowShapeProvider {
   std::reference_wrapper<const casacore::TableColumn> column_;
   std::reference_wrapper<const ColumnSelection> selection_;
+  bool is_fixed_;
   std::shared_ptr<arrow::Array> data_;
   std::shared_ptr<arrow::DataType> data_type_;
   std::optional<casacore::IPosition> shape_;
@@ -40,7 +41,7 @@ struct ArrowShapeProvider {
                                                 const std::shared_ptr<arrow::Array> & data);
 
   // returns true if the column shape is fixed
-  bool IsColumnFixed() const { return column_.get().columnDesc().isFixedShape(); }
+  bool IsColumnFixed() const { return is_fixed_; }
 
   // return true if the column shape varys
   bool IsColumnVarying() const { return !IsColumnFixed(); }


### PR DESCRIPTION
`ShapeProvider::nDim()` methods were calling `TableColumn::columnDesc()`. Even though this returned a `ColumnDesc &`, creation and destruction of `ColumnDesc` objects were triggered internally. This change avoids this.