### PR TITLE
Build updates

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,8 @@ History
 
 X.Y.Z (YYYY-MM-DD)
 ------------------
+* Avoid stripping debug information (:pr:`96`)
+* Set cmake build type to RelWithDebInfo (:pr:`96`)
 * Avoid creating ColumnDesc objects in inner loops (:pr:`95`)
 * Support Table arguments in TAQL queries (:pr:`93`)
 * Upgrade to pyarrow 16.0.0 (:pr:`92`)

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -1,10 +1,8 @@
 find_package(GTest CONFIG REQUIRED)
 
 add_library(test_utils test_utils.cc)
-# add_compile_options("-fsanitize=address")
-# add_link_options("-fsanitize=address")
-add_compile_options("-g")
-add_link_options("-g")
+add_compile_options("-fsanitize=address")
+add_link_options("-fsanitize=address")
 
 add_executable(basic_test basic_test.cc)
 target_link_libraries(basic_test PRIVATE GTest::gtest_main arcae test_utils)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,3 +53,4 @@ find = {}
 [tool.scikit-build]
 # build-dir = "/tmp/arcae"
 cmake.minimum-version = "3.26.1"
+cmake.build-type = "RelWithDebInfo"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,3 +54,4 @@ find = {}
 # build-dir = "/tmp/arcae"
 cmake.minimum-version = "3.26.1"
 cmake.build-type = "RelWithDebInfo"
+install.strip = false


### PR DESCRIPTION
- Set release type to `RelWithDebInfo`
- Don't strip debug info when building the wheel
- Re-add address santizer to test cases