### PR TITLE
Upgrade to cibuildwheel 2.19.1

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,6 +1,6 @@
 build_and_store_wheels: &BUILD_AND_STORE_WHEELS
   install_cibuildwheel_script:
-    - python -m pip install cibuildwheel==2.17
+    - python -m pip install cibuildwheel==2.19.1
   run_cibuildwheel_script:
     - cibuildwheel
   wheels_artifacts:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ env:
   # Need to reinstall gcc in order to get gfortran
   CIBW_BEFORE_ALL_MACOS: |
     brew install python llvm
-    brew reinstall gcc --build-from-source
+    brew reinstall gcc
   CIBW_BEFORE_BUILD_MACOS: |
     export PATH="/opt/homebrew/opt/llvm/bin:$PATH"
     export LDFLAGS="-L/opt/homebrew/opt/llvm/lib"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,8 +191,6 @@ jobs:
               -v {wheel} \
               --exclude libarrow_python.dylib \
               --exclude libarrow.1600.dylib \
-              --exclude libgfortran.5.dylib \
-              --exclude libquadmath.0.dylib \
               --ignore-missing-dependencies
 
       - name: Upload wheel artifacts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,6 +191,8 @@ jobs:
               -v {wheel} \
               --exclude libarrow_python.dylib \
               --exclude libarrow.1600.dylib \
+              --exclude libgfortran.5.dylib \
+              --exclude libquadmath.0.dylib \
               --ignore-missing-dependencies
 
       - name: Upload wheel artifacts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ env:
   # Need to reinstall gcc in order to get gfortran
   CIBW_BEFORE_ALL_MACOS: |
     brew install python llvm
-    brew reinstall gcc
+    brew reinstall gcc --build-from-source
   CIBW_BEFORE_BUILD_MACOS: |
     export PATH="/opt/homebrew/opt/llvm/bin:$PATH"
     export LDFLAGS="-L/opt/homebrew/opt/llvm/lib"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,7 +170,7 @@ jobs:
         run: echo "CIBW_ENVIRONMENT_COMMON=$COMMON_ENV" >> $GITHUB_ENV
 
       - name: Run cibuildwheel
-        uses: pypa/cibuildwheel@v2.17
+        uses: pypa/cibuildwheel@v2.19.1
         env:
           CIBW_BUILD: ${{ matrix.cpython }}-${{ matrix.extra_build }}*
           CIBW_ARCHS: ${{ matrix.arch }}


### PR DESCRIPTION
Upgrading to `cibuildwheel` and, transitively, `delocate` reveals the following problem:

- https://github.com/matthew-brett/delocate/issues/211

This has been summarised in the following arcae issue:

- https://github.com/ratt-ru/arcae/issues/99