### PR TITLE
Restrict numpy  to less than 2.0.0

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 X.Y.Z (YYYY-MM-DD)
 ------------------
+* Restrict Numpy to less than 2.0.0 (:pr:`100`)
 * Avoid stripping debug information (:pr:`96`)
 * Set cmake build type to RelWithDebInfo (:pr:`96`)
 * Avoid creating ColumnDesc objects in inner loops (:pr:`95`)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ classifiers = [
 ]
 dependencies = [
     "appdirs",
+    "numpy < 2.0.0",
     "pyarrow == 16.0.0"
 ]
 
@@ -44,6 +45,7 @@ Repository = "https://github.com/ratt-ru/arcae"
 requires = [
     "cython>=3.0.2",
     "scikit-build-core",
+    "numpy < 2.0.0",
     "pyarrow == 16.0.0"]
 build-backend = "scikit_build_core.build"
 


### PR DESCRIPTION
pyarrow 16.0.0 has compatibility with the previous numpy ABI.