### PR TITLE
Pin manylinux_2_28 image to manylinux_2_28_x86_64:2024.07.02-0

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -10,7 +10,7 @@ env:
   VCPKG_INSTALLED_DIR: /tmp/vcpkg_installed
   CIBW_BUILD_FRONTEND: build
   CIBW_BEFORE_ALL_LINUX: yum install -y zip flex bison gcc-gfortran
-  CIBW_MANYLINUX_AARCH64_IMAGE: quay.io/pypa/manylinux_2_28_aarch64
+  CIBW_MANYLINUX_AARCH64_IMAGE: quay.io/pypa/manylinux_2_28_x86_64:2024.07.02-0
   CIBW_REPAIR_WHEEL_COMMAND_LINUX: >
     auditwheel repair -w {dest_dir} {wheel}
     --exclude libarrow_python.so

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -10,7 +10,7 @@ env:
   VCPKG_INSTALLED_DIR: /tmp/vcpkg_installed
   CIBW_BUILD_FRONTEND: build
   CIBW_BEFORE_ALL_LINUX: yum install -y zip flex bison gcc-gfortran
-  CIBW_MANYLINUX_AARCH64_IMAGE: quay.io/pypa/manylinux_2_28_x86_64:2024.07.02-0
+  CIBW_MANYLINUX_AARCH64_IMAGE: quay.io/pypa/manylinux_2_28_aarch64:2024.07.02-0
   CIBW_REPAIR_WHEEL_COMMAND_LINUX: >
     auditwheel repair -w {dest_dir} {wheel}
     --exclude libarrow_python.so

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ env:
     export PATH="/opt/homebrew/opt/llvm/bin:$PATH"
     export LDFLAGS="-L/opt/homebrew/opt/llvm/lib"
     export CPPFLAGS="-I/opt/homebrew/opt/llvm/include"
-  CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/manylinux_2_28_x86_64
+  CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/manylinux_2_28_x86_64:2024.07.02-0
   CIBW_TEST_EXTRAS_LINUX: applications,test
   CIBW_TEST_COMMAND_LINUX: py.test -s -vvv --pyargs arcae
   CIBW_TEST_COMMAND_MACOS: python -c "from arcae.testing import sanity; sanity()"

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 X.Y.Z (YYYY-MM-DD)
 ------------------
+* Pin manylinux_2_28 image to manylinux_2_28_x86_64:2024.07.02-0 (:pr:`102`)
 * Restrict Numpy to less than 2.0.0 (:pr:`100`)
 * Avoid stripping debug information (:pr:`96`)
 * Set cmake build type to RelWithDebInfo (:pr:`96`)


### PR DESCRIPTION
`manylinux_2_28_x86_64:latest` breaks the vcpkg's build of cfitsio with the following class of linker errors:

```bash
...
FAILED: Funpack 
: && /opt/rh/gcc-toolset-12/root/usr/bin/gcc  -pthread -fPIC -O3 -DNDEBUG -rdynamic CMakeFiles/Funpack.dir/funpack.c.o CMakeFiles/Funpack.dir/fpackutil.c.o -o Funpack  -Wl,-rpath,/project/vcpkg/source/buildtrees/cfitsio/x64-linux-dynamic-cxx17-abi1-rel-rel:/project/vcpkg/installed/x64-linux-dynamic-cxx17-abi1-rel/lib  libcfitsio.so.3.49  -lm  /project/vcpkg/installed/x64-linux-dynamic-cxx17-abi1-rel/lib/libz.so && :
/opt/rh/gcc-toolset-12/root/usr/libexec/gcc/x86_64-redhat-linux/12/ld: libcfitsio.so.3.49: undefined reference to `strtok_s'
collect2: error: ld returned 1 exit status
ninja: build stopped: subcommand failed.
```

See https://github.com/ratt-ru/arcae/actions/runs/9832660416