### PR TITLE
Use casacore::RefRows for indexing the row dimension

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 X.Y.Z (YYYY-MM-DD)
 ------------------
+* Use casacore::RefRows for indexing the row dimension (:pr:`105`)
 * Refactor arcae to use a finer-grained execution model (:pr:`101`)
 * Pin manylinux_2_28 image to manylinux_2_28_x86_64:2024.07.02-0 (:pr:`102`)
 * Restrict Numpy to less than 2.0.0 (:pr:`100`)

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -21,19 +21,8 @@ target_compile_options(arcae PRIVATE
     $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:
         -Wall -Werror -pedantic>)
 target_link_directories(arcae PUBLIC ${PYARROW_LIBDIRS})
-target_link_libraries(arcae
-    PkgConfig::casacore
-    arrow
-    absl::span
-    absl::time
-    absl::str_format)
-target_include_directories(arcae PUBLIC
-    PkgConfig::casacore
-    absl::span
-    absl::time
-    absl::str_format
-    ${PYARROW_INCLUDE}
-    ${CMAKE_INCLUDE_CURRENT_DIR})
+target_link_libraries(arcae PkgConfig::casacore arrow absl::span)
+target_include_directories(arcae PUBLIC PkgConfig::casacore absl::span ${PYARROW_INCLUDE} ${CMAKE_INCLUDE_CURRENT_DIR})
 
 set_target_properties(arcae PROPERTIES
     POSITION_INDEPENDENT_CODE 1)

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -21,8 +21,19 @@ target_compile_options(arcae PRIVATE
     $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:
         -Wall -Werror -pedantic>)
 target_link_directories(arcae PUBLIC ${PYARROW_LIBDIRS})
-target_link_libraries(arcae PkgConfig::casacore arrow absl::span)
-target_include_directories(arcae PUBLIC PkgConfig::casacore absl::span ${PYARROW_INCLUDE} ${CMAKE_INCLUDE_CURRENT_DIR})
+target_link_libraries(arcae
+    PkgConfig::casacore
+    arrow
+    absl::span
+    absl::time
+    absl::str_format)
+target_include_directories(arcae PUBLIC
+    PkgConfig::casacore
+    absl::span
+    absl::time
+    absl::str_format
+    ${PYARROW_INCLUDE}
+    ${CMAKE_INCLUDE_CURRENT_DIR})
 
 set_target_properties(arcae PROPERTIES
     POSITION_INDEPENDENT_CODE 1)

--- a/cpp/arcae/data_partition.h
+++ b/cpp/arcae/data_partition.h
@@ -2,6 +2,7 @@
 #define ARCAE_DATA_PARTITION_H
 
 #include <cassert>
+#include <sstream>
 #include <vector>
 
 #include <absl/types/span.h>
@@ -198,6 +199,28 @@ struct DataChunk {
     std::size_t nbytes = CasaDataTypeSize(CasaDataType()).ValueOrDie();
     return nbytes * nElements();
   }
+
+  std::string ToString() const {
+    std::ostringstream oss;
+    oss << "Chunk(" << GetShape() << ','
+        << CasaDataType() << ',';
+
+    float nbytes = nBytes();
+    float display = nbytes;
+    float increment = 1024;
+
+    for(auto name: {"B", "KB", "MB", "GB"}) {
+      if(nbytes > increment) {
+        increment *= 1024.;
+        display /= 1024.;
+      } else {
+        oss << display << name;
+        break;
+      }
+    }
+    oss << ')';
+    return oss.str();
+  };
 
   // Shape of the chunk
   casacore::IPosition GetShape() const noexcept;

--- a/cpp/arcae/data_partition.h
+++ b/cpp/arcae/data_partition.h
@@ -2,7 +2,6 @@
 #define ARCAE_DATA_PARTITION_H
 
 #include <cassert>
-#include <sstream>
 #include <vector>
 
 #include <absl/types/span.h>
@@ -199,28 +198,6 @@ struct DataChunk {
     std::size_t nbytes = CasaDataTypeSize(CasaDataType()).ValueOrDie();
     return nbytes * nElements();
   }
-
-  std::string ToString() const {
-    std::ostringstream oss;
-    oss << "Chunk(" << GetShape() << ','
-        << CasaDataType() << ',';
-
-    float nbytes = nBytes();
-    float display = nbytes;
-    float increment = 1024;
-
-    for(auto name: {"B", "KB", "MB", "GB"}) {
-      if(nbytes > increment) {
-        increment *= 1024.;
-        display /= 1024.;
-      } else {
-        oss << display << name;
-        break;
-      }
-    }
-    oss << ')';
-    return oss.str();
-  };
 
   // Shape of the chunk
   casacore::IPosition GetShape() const noexcept;

--- a/cpp/arcae/data_partition.h
+++ b/cpp/arcae/data_partition.h
@@ -10,9 +10,11 @@
 
 #include <casacore/casa/Arrays/IPosition.h>
 #include <casacore/casa/Utilities/DataType.h>
+#include <casacore/tables/Tables/RefRows.h>
 
 #include "arcae/result_shape.h"
 #include "arcae/selection.h"
+#include "arcae/type_traits.h"
 
 namespace arcae {
 namespace detail {
@@ -180,6 +182,9 @@ struct DataChunk {
   // Get a Row Slicer for the disk span
   casacore::Slicer RowSlicer() const noexcept;
 
+  // Get Reference Rows for the disk span
+  casacore::RefRows ReferenceRows() const noexcept;
+
   // Get a Section Slicer for the disk span
   casacore::Slicer SectionSlicer() const noexcept;
 
@@ -188,6 +193,11 @@ struct DataChunk {
 
   // Number of elements in the chunk
   std::size_t nElements() const noexcept;
+
+  std::size_t nBytes() const {
+    std::size_t nbytes = CasaDataTypeSize(CasaDataType()).ValueOrDie();
+    return nbytes * nElements();
+  }
 
   // Shape of the chunk
   casacore::IPosition GetShape() const noexcept;

--- a/cpp/arcae/read_impl.cc
+++ b/cpp/arcae/read_impl.cc
@@ -5,9 +5,6 @@
 #include <memory>
 #include <string>
 
-#include <absl/time/clock.h>
-#include <absl/time/time.h>
-
 #include <arrow/api.h>
 #include <arrow/buffer.h>
 #include <arrow/result.h>
@@ -100,11 +97,6 @@ struct ReadCallback {
         chunk = chunk,
         buffer = buffer
       ](const TableProxy & tp) -> Future<bool> {
-        std::shared_ptr<void> time_it(nullptr, [&, start = absl::Now()](...) {
-          ARROW_LOG(INFO) << "Read " << chunk.ToString()
-                          << " contiguous in " << absl::Now() - start << " seconds";
-        });
-
         auto out_ptr = buffer->template mutable_data_as<CT>() + chunk.FlatOffset();
         auto shape = chunk.GetShape();
         if(shape.size() == 1) {
@@ -125,11 +117,6 @@ struct ReadCallback {
       column_name = std::move(column),
       chunk = chunk
     ](const TableProxy & tp) -> Future<CasaArray<CT>> {
-        std::shared_ptr<void> time_it(nullptr, [&, start = absl::Now()](...) {
-          ARROW_LOG(INFO) << "Read " << chunk.ToString()
-                          << " in " << absl::Now() - start << " seconds";
-        });
-
       if(chunk.nDim() == 1) {
         auto column = ScalarColumn<CT>(tp.table(), column_name);
         return column.getColumnCells(chunk.ReferenceRows());
@@ -143,11 +130,6 @@ struct ReadCallback {
       chunk = chunk,
       buffer = buffer
     ](const CasaArray<CT> & data) mutable -> bool {
-        std::shared_ptr<void> time_it(nullptr, [&, start = absl::Now()](...) {
-          ARROW_LOG(INFO) << "Transposed " << chunk.ToString()
-                          << " in " << absl::Now() - start << " seconds";
-        });
-
       std::ptrdiff_t ndim = chunk.nDim();
       std::ptrdiff_t last_dim = ndim - 1;
       auto spans = chunk.DimensionSpans();

--- a/cpp/arcae/read_impl.cc
+++ b/cpp/arcae/read_impl.cc
@@ -102,12 +102,12 @@ struct ReadCallback {
         if(shape.size() == 1) {
           auto column = ScalarColumn<CT>(tp.table(), column_name);
           auto data = CasaVector<CT>(chunk.GetShape(), out_ptr, casacore::SHARE);
-          column.getColumnRange(chunk.RowSlicer(), data);
+          column.getColumnCells(chunk.ReferenceRows(), data);
           return true;
         }
         auto column = ArrayColumn<CT>(tp.table(), column_name);
         auto data = CasaArray<CT>(chunk.GetShape(), out_ptr, casacore::SHARE);
-        column.getColumnRange(chunk.RowSlicer(), chunk.SectionSlicer(), data);
+        column.getColumnCells(chunk.ReferenceRows(), chunk.SectionSlicer(), data);
         return true;
       });
     }
@@ -119,10 +119,10 @@ struct ReadCallback {
     ](const TableProxy & tp) -> Future<CasaArray<CT>> {
       if(chunk.nDim() == 1) {
         auto column = ScalarColumn<CT>(tp.table(), column_name);
-        return column.getColumnRange(chunk.RowSlicer());
+        return column.getColumnCells(chunk.ReferenceRows());
       }
       auto column = ArrayColumn<CT>(tp.table(), column_name);
-      return column.getColumnRange(chunk.RowSlicer(), chunk.SectionSlicer());
+      return column.getColumnCells(chunk.ReferenceRows(), chunk.SectionSlicer());
     });
 
     // Transpose the array into the output buffer

--- a/cpp/arcae/write_impl.cc
+++ b/cpp/arcae/write_impl.cc
@@ -88,12 +88,12 @@ struct WriteCallback {
         if(shape.size() == 1) {
           auto column = ScalarColumn<CT>(tp.table(), column_name);
           auto vector = CasaVector<CT>(shape, in_ptr, casacore::SHARE);
-          column.putColumnRange(chunk.RowSlicer(), vector);
+          column.putColumnCells(chunk.ReferenceRows(), vector);
           return true;
         }
         auto column = ArrayColumn<CT>(tp.table(), column_name);
         auto array = CasaArray<CT>(shape, in_ptr, casacore::SHARE);
-        column.putColumnRange(chunk.RowSlicer(), chunk.SectionSlicer(), array);
+        column.putColumnCells(chunk.ReferenceRows(), chunk.SectionSlicer(), array);
         return true;
       });
     }
@@ -143,11 +143,11 @@ struct WriteCallback {
       ](const CasaArray<CT> & data, const TableProxy & tp) -> bool {
         if(chunk.nDim() == 1) {
           auto column = ScalarColumn<CT>(tp.table(), column_name);
-          column.putColumnRange(chunk.RowSlicer(), data);
+          column.putColumnCells(chunk.ReferenceRows(), data);
           return true;
         }
         auto column = ArrayColumn<CT>(tp.table(), column_name);
-        column.putColumnRange(chunk.RowSlicer(), chunk.SectionSlicer(), data);
+        column.putColumnCells(chunk.ReferenceRows(), chunk.SectionSlicer(), data);
         return true;
       });
   }

--- a/cpp/tests/data_partition_test.cc
+++ b/cpp/tests/data_partition_test.cc
@@ -39,7 +39,7 @@ TEST(DataPartitionTest, Fixed) {
                       .Build();                   // 1 x 2 x 3
 
   ASSERT_OK_AND_ASSIGN(auto partition, DataPartition::Make(selection, result_shape));
-  EXPECT_EQ(partition.nChunks(), 6);
+  EXPECT_EQ(partition.nChunks(), 4);
 
   EXPECT_THAT(partition.Chunk(0).Disk(0), ::testing::ElementsAre(0, 1));
   EXPECT_THAT(partition.Chunk(0).Mem(0), ::testing::ElementsAre(0, 1));
@@ -47,8 +47,8 @@ TEST(DataPartitionTest, Fixed) {
   EXPECT_THAT(partition.Chunk(0).Mem(1), ::testing::ElementsAre(1, 2));
   EXPECT_THAT(partition.Chunk(0).Disk(2), ::testing::ElementsAre(-1, -1));
   EXPECT_THAT(partition.Chunk(0).Mem(2), ::testing::ElementsAre(2, 5));
-  EXPECT_EQ(partition.Chunk(0).RowSlicer(),
-            Slicer(IPosition({-1}), IPosition({-1}), Slicer::endIsLast));
+  EXPECT_THAT(partition.Chunk(0).ReferenceRows().rowVector(),
+              ::testing::ElementsAre(-1, -1));
   EXPECT_EQ(partition.Chunk(0).SectionSlicer(),
             Slicer(IPosition({0, 0}), IPosition({1, 1}), Slicer::endIsLast));
 
@@ -56,55 +56,33 @@ TEST(DataPartitionTest, Fixed) {
   EXPECT_THAT(partition.Chunk(1).Mem(0), ::testing::ElementsAre(0, 1));
   EXPECT_THAT(partition.Chunk(1).Disk(1), ::testing::ElementsAre(0, 1));
   EXPECT_THAT(partition.Chunk(1).Mem(1), ::testing::ElementsAre(1, 2));
-  EXPECT_THAT(partition.Chunk(1).Disk(2), ::testing::ElementsAre(1, 2));
-  EXPECT_THAT(partition.Chunk(1).Mem(2), ::testing::ElementsAre(1, 0));
-  EXPECT_EQ(partition.Chunk(1).RowSlicer(),
-            Slicer(IPosition({1}), IPosition({2}), Slicer::endIsLast));
+  EXPECT_THAT(partition.Chunk(1).Disk(2), ::testing::ElementsAre(1, 2, 5, 6));
+  EXPECT_THAT(partition.Chunk(1).Mem(2), ::testing::ElementsAre(1, 0, 3, 4));
+  EXPECT_THAT(partition.Chunk(1).ReferenceRows().rowVector(),
+              ::testing::ElementsAre(1, 2, 5, 6));
   EXPECT_EQ(partition.data_chunks_[1].SectionSlicer(),
             Slicer(IPosition({0, 0}), IPosition({1, 1}), Slicer::endIsLast));
 
   EXPECT_THAT(partition.Chunk(2).Disk(0), ::testing::ElementsAre(0, 1));
   EXPECT_THAT(partition.Chunk(2).Mem(0), ::testing::ElementsAre(0, 1));
-  EXPECT_THAT(partition.Chunk(2).Disk(1), ::testing::ElementsAre(0, 1));
-  EXPECT_THAT(partition.Chunk(2).Mem(1), ::testing::ElementsAre(1, 2));
-  EXPECT_THAT(partition.Chunk(2).Disk(2), ::testing::ElementsAre(5, 6));
-  EXPECT_THAT(partition.Chunk(2).Mem(2), ::testing::ElementsAre(3, 4));
-  EXPECT_EQ(partition.Chunk(2).RowSlicer(),
-            Slicer(IPosition({5}), IPosition({6}), Slicer::endIsLast));
+  EXPECT_THAT(partition.Chunk(2).Disk(1), ::testing::ElementsAre(3));
+  EXPECT_THAT(partition.Chunk(2).Mem(1), ::testing::ElementsAre(0));
+  EXPECT_THAT(partition.Chunk(2).Disk(2), ::testing::ElementsAre(-1, -1));
+  EXPECT_THAT(partition.Chunk(2).Mem(2), ::testing::ElementsAre(2, 5));
+  EXPECT_THAT(partition.Chunk(2).ReferenceRows().rowVector(),
+              ::testing::ElementsAre(-1, -1));
   EXPECT_EQ(partition.Chunk(2).SectionSlicer(),
-            Slicer(IPosition({0, 0}), IPosition({1, 1}), Slicer::endIsLast));
+            Slicer(IPosition({0, 3}), IPosition({1, 3}), Slicer::endIsLast));
 
   EXPECT_THAT(partition.Chunk(3).Disk(0), ::testing::ElementsAre(0, 1));
   EXPECT_THAT(partition.Chunk(3).Mem(0), ::testing::ElementsAre(0, 1));
   EXPECT_THAT(partition.Chunk(3).Disk(1), ::testing::ElementsAre(3));
   EXPECT_THAT(partition.Chunk(3).Mem(1), ::testing::ElementsAre(0));
-  EXPECT_THAT(partition.Chunk(3).Disk(2), ::testing::ElementsAre(-1, -1));
-  EXPECT_THAT(partition.Chunk(3).Mem(2), ::testing::ElementsAre(2, 5));
-  EXPECT_EQ(partition.Chunk(3).RowSlicer(),
-            Slicer(IPosition({-1}), IPosition({-1}), Slicer::endIsLast));
+  EXPECT_THAT(partition.Chunk(3).Disk(2), ::testing::ElementsAre(1, 2, 5, 6));
+  EXPECT_THAT(partition.Chunk(3).Mem(2), ::testing::ElementsAre(1, 0, 3, 4));
+  EXPECT_THAT(partition.Chunk(3).ReferenceRows().rowVector(),
+              ::testing::ElementsAre(1, 2, 5, 6));
   EXPECT_EQ(partition.Chunk(3).SectionSlicer(),
-            Slicer(IPosition({0, 3}), IPosition({1, 3}), Slicer::endIsLast));
-
-  EXPECT_THAT(partition.Chunk(4).Disk(0), ::testing::ElementsAre(0, 1));
-  EXPECT_THAT(partition.Chunk(4).Mem(0), ::testing::ElementsAre(0, 1));
-  EXPECT_THAT(partition.Chunk(4).Disk(1), ::testing::ElementsAre(3));
-  EXPECT_THAT(partition.Chunk(4).Mem(1), ::testing::ElementsAre(0));
-  EXPECT_THAT(partition.Chunk(4).Disk(2), ::testing::ElementsAre(1, 2));
-  EXPECT_THAT(partition.Chunk(4).Mem(2), ::testing::ElementsAre(1, 0));
-  EXPECT_EQ(partition.Chunk(4).RowSlicer(),
-            Slicer(IPosition({1}), IPosition({2}), Slicer::endIsLast));
-  EXPECT_EQ(partition.Chunk(4).SectionSlicer(),
-            Slicer(IPosition({0, 3}), IPosition({1, 3}), Slicer::endIsLast));
-
-  EXPECT_THAT(partition.Chunk(5).Disk(0), ::testing::ElementsAre(0, 1));
-  EXPECT_THAT(partition.Chunk(5).Mem(0), ::testing::ElementsAre(0, 1));
-  EXPECT_THAT(partition.Chunk(5).Disk(1), ::testing::ElementsAre(3));
-  EXPECT_THAT(partition.Chunk(5).Mem(1), ::testing::ElementsAre(0));
-  EXPECT_THAT(partition.Chunk(5).Disk(2), ::testing::ElementsAre(5, 6));
-  EXPECT_THAT(partition.Chunk(5).Mem(2), ::testing::ElementsAre(3, 4));
-  EXPECT_EQ(partition.Chunk(5).RowSlicer(),
-            Slicer(IPosition({5}), IPosition({6}), Slicer::endIsLast));
-  EXPECT_EQ(partition.Chunk(5).SectionSlicer(),
             Slicer(IPosition({0, 3}), IPosition({1, 3}), Slicer::endIsLast));
 }
 

--- a/vcpkg/overlay-ports/casacore/001-casacore-cmake.patch
+++ b/vcpkg/overlay-ports/casacore/001-casacore-cmake.patch
@@ -589,6 +589,62 @@ index 452e33cd3..bb46a0dba 100644
  };
  
  
+diff --git a/tables/Tables/RefRows.cc b/tables/Tables/RefRows.cc
+index 6eab06474..5863abf69 100644
+--- a/tables/Tables/RefRows.cc
++++ b/tables/Tables/RefRows.cc
+@@ -40,17 +40,24 @@ RefRows::RefRows (const Vector<rownr_t>& rowNumbers, Bool isSliced,
+   init (rowNumbers, isSliced, collapse);
+ }
+ 
++RefRows::RefRows (Vector<rownr_t>&& rowNumbers, Bool isSliced,
++		  Bool collapse)
++{
++  init (std::move(rowNumbers), isSliced, collapse);
++}
++
++
+ RefRows::RefRows (const Vector<uInt>& rowNumbers, Bool isSliced,
+ 		  Bool collapse)
+ {
+   init (RowNumbers(rowNumbers), isSliced, collapse);
+ }
+-  
+-void RefRows::init (const Vector<rownr_t>& rowNumbers, Bool isSliced,
++
++void RefRows::init (Vector<rownr_t> rowNumbers, Bool isSliced,
+                     Bool collapse)
+ {
+-  itsRows   = rowNumbers;
+-  itsNrows  = rowNumbers.nelements();
++  itsRows   = std::move(rowNumbers);
++  itsNrows  = itsRows.nelements();
+   itsSliced = isSliced;
+     if (itsSliced) {
+ 	AlwaysAssert (itsNrows%3 == 0, AipsError);
+diff --git a/tables/Tables/RefRows.h b/tables/Tables/RefRows.h
+index 83af03dda..d31c807d6 100644
+--- a/tables/Tables/RefRows.h
++++ b/tables/Tables/RefRows.h
+@@ -94,6 +94,9 @@ public:
+     // individual row numbers to the slice form (to save memory).
+     RefRows (const Vector<rownr_t>& rowNumbers, Bool isSliced = False,
+              Bool collapse = False);
++
++    RefRows (Vector<rownr_t>&& rowNumbers, Bool isSliced = False,
++             Bool collapse = False);
+ #ifdef IMPLICIT_CTDS_32BIT
+     RefRows (const Vector<uInt>& rowNumbers, Bool isSliced = False,
+              Bool collapse = False);
+@@ -150,7 +153,7 @@ public:
+ 
+ private:
+     // Initialize the object.
+-    void init (const Vector<rownr_t>& rowNumbers, Bool isSliced,
++    void init (Vector<rownr_t> rowNumbers, Bool isSliced,
+                Bool collapse);
+ 
+     // Fill the itsNrows variable.
 diff --git a/tables/Tables/TableProxy.cc b/tables/Tables/TableProxy.cc
 index 66865e52d..4bd489373 100644
 --- a/tables/Tables/TableProxy.cc


### PR DESCRIPTION
Previously, the row dimension was partitioned into separate, contiguous ranges which were retrieved in separate operations.

This PR modifies data read and write to submit all rows as a single operation.