### PR TITLE
Restrict Cython to < 3.0.10

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 X.Y.Z (YYYY-MM-DD)
 ------------------
+* Pin cython to less than 3.0.10 (:pr:`106`)
 * Use casacore::RefRows for indexing the row dimension (:pr:`105`)
 * Refactor arcae to use a finer-grained execution model (:pr:`101`)
 * Pin manylinux_2_28 image to manylinux_2_28_x86_64:2024.07.02-0 (:pr:`102`)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ Repository = "https://github.com/ratt-ru/arcae"
 
 [build-system]
 requires = [
-    "cython>=3.0.2",
+    "cython>=3.0.2, < 3.0.10",
     "scikit-build-core",
     "numpy < 2.0.0",
     "pyarrow == 16.0.0"]


### PR DESCRIPTION
3.0.10 and higher causes:

- https://github.com/cython/cython/issues/6249