### PR TITLE
Re-implement partial support for unconstrained columns

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,8 @@ History
 
 X.Y.Z (YYYY-MM-DD)
 ------------------
+* Re-implement partial support for selection over unconstrained columns
+  that, in practice, have the same rank (:pr:`108`)
 * Unpin manylinux_2_28_x86_64 image (:pr:`107`)
 * Pin cython to less than 3.0.10 (:pr:`106`)
 * Use casacore::RefRows for indexing the row dimension (:pr:`105`)

--- a/cpp/arcae/data_partition.cc
+++ b/cpp/arcae/data_partition.cc
@@ -320,7 +320,7 @@ DataChunk::IsEmpty() const noexcept {
   for(const auto & span: DimensionSpans()) {
     for(auto i: span.disk) { if (i < 0) return true; }
   }
-  return false;
+  return nElements() == 0;
 }
 
 // Commented out debugging function

--- a/src/arcae/tests/test_pytable.py
+++ b/src/arcae/tests/test_pytable.py
@@ -33,7 +33,7 @@ def test_column_selection(column_case_table):
             "SCALAR",
             "SCALAR_STRING",
             # Even though the column is unconstrained, ndim is the same
-            #"UNCONSTRAINED_SAME_NDIM",
+            "UNCONSTRAINED_SAME_NDIM",
             "VARIABLE",
             "VARIABLE_STRING"
         ]
@@ -44,7 +44,7 @@ def test_column_selection(column_case_table):
             "FIXED_STRING",
             "SCALAR",
             "SCALAR_STRING",
-            #"UNCONSTRAINED_SAME_NDIM",
+            "UNCONSTRAINED_SAME_NDIM",
             "VARIABLE",
             "VARIABLE_STRING"
         ]


### PR DESCRIPTION
Re-implement support for selections over unconstrained columns that, in practice, have the same rank.

This was not  initially present in:

- #101 