### PR TITLE
Handle arrays and tables with no rows

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 X.Y.Z (YYYY-MM-DD)
 ------------------
+* Handle arrays and tables with no rows (:pr:`112`)
 * Drop the Global Interpreter Lock (:pr:`111`)
 * Remove FFTW3 and casacore apps from the casacore build (:pr:`110``)
 * Add table name method (:pr:`109`)

--- a/cpp/arcae/data_partition.cc
+++ b/cpp/arcae/data_partition.cc
@@ -242,9 +242,12 @@ MakeDataChunks(
 
     // Compute minimum element
     for(std::size_t d = 0; d < ndim; ++d) {
-      shared->min_mem_index_[offset + d] = *std::min_element(
-        std::begin(dim_span[d].mem),
-        std::end(dim_span[d].mem));
+      shared->min_mem_index_[offset + d] = [&]() -> std::size_t {
+        if(dim_span[d].mem.size() == 0) return 0;
+        return *std::min_element(
+          std::begin(dim_span[d].mem),
+          std::end(dim_span[d].mem));
+      }();
     }
 
     // Compute flat offsets


### PR DESCRIPTION
This mostly worked, except for a null pointer dereference in the case of finding the minimum element in array of size 0.