### PR TITLE
Multiplex CASA Table I/O over multiple table instances

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 X.Y.Z (YYYY-MM-DD)
 ------------------
+* Multiplex CASA Table I/O over multiple table instances (:pr:`113`)
 * Handle arrays and tables with no rows (:pr:`112`)
 * Drop the Global Interpreter Lock (:pr:`111`)
 * Remove FFTW3 and casacore apps from the casacore build (:pr:`110``)

--- a/cpp/arcae/isolated_table_proxy.cc
+++ b/cpp/arcae/isolated_table_proxy.cc
@@ -1,11 +1,22 @@
 #include "arcae/isolated_table_proxy.h"
 
+#include <cassert>
+#include <cstddef>
+#include <limits>
 #include <memory>
 
 #include <arrow/util/logging.h>
+#include "arrow/status.h"
+#include "arrow/util/functional.h"
+#include "arrow/util/future.h"
+#include "arrow/util/thread_pool.h"
 
 #include <casacore/tables/Tables/TableProxy.h>
 
+using ::arrow::Future;
+using ::arrow::Result;
+using ::arrow::Status;
+using ::arrow::internal::ThreadPool;
 using ::casacore::TableProxy;
 
 namespace arcae {
@@ -16,14 +27,60 @@ IsolatedTableProxy::IsClosed() const {
   return is_closed_;
 }
 
-arrow::Result<bool>
+std::size_t
+IsolatedTableProxy::GetInstance() const {
+  using NumTasksType = decltype(ProxyAndPool::io_pool_->GetNumTasks());
+  std::size_t instance = 0;
+  NumTasksType num_tasks = std::numeric_limits<NumTasksType>::max();
+  assert(proxy_pools_ && proxy_pools_.size() > 0);
+
+  for(std::size_t i = 0; i < proxy_pools_.size(); ++i) {
+    const auto & pool = proxy_pools_[i].io_pool_;
+    const auto pool_tasks = pool->GetNumTasks();
+    if(pool_tasks < num_tasks) {
+      instance = i;
+      num_tasks = pool_tasks;
+    }
+  }
+
+  return instance;
+}
+
+
+const std::shared_ptr<TableProxy> &
+IsolatedTableProxy::GetProxy(std::size_t instance) const {
+  assert(instance < proxy_pools_.size());
+  return proxy_pools_[instance].table_proxy_;
+}
+
+
+const std::shared_ptr<ThreadPool> &
+IsolatedTableProxy::GetPool(std::size_t instance) const {
+  assert(instance < proxy_pools_.size());
+  return proxy_pools_[instance].io_pool_;
+}
+
+Status
+IsolatedTableProxy::CheckClosed() const {
+  if(!is_closed_) return Status::OK();
+  return Status::Invalid("TableProxy is closed");
+}
+
+Result<bool>
 IsolatedTableProxy::Close() {
   if(!is_closed_) {
     std::shared_ptr<void> defer_close(nullptr, [this](...) { this->is_closed_ = true; });
-    return RunSync([](TableProxy & tp) {
-      tp.close();
-      return true;
-    });
+    std::vector<Future<bool>> results;
+    results.reserve(proxy_pools_.size());
+    for(auto & [proxy, pool] : proxy_pools_) {
+      results.push_back(arrow::DeferNotOk(pool->Submit([tp = proxy]() {
+        tp->close();
+        return true;
+      })));
+    }
+    auto all_done = arrow::All(results);
+    all_done.Wait();
+    return true;
   }
   return false;
 }

--- a/cpp/arcae/isolated_table_proxy.cc
+++ b/cpp/arcae/isolated_table_proxy.cc
@@ -32,7 +32,7 @@ IsolatedTableProxy::GetInstance() const {
   using NumTasksType = decltype(ProxyAndPool::io_pool_->GetNumTasks());
   std::size_t instance = 0;
   NumTasksType num_tasks = std::numeric_limits<NumTasksType>::max();
-  assert(proxy_pools_ && proxy_pools_.size() > 0);
+  assert(proxy_pools_.size() > 0);
 
   for(std::size_t i = 0; i < proxy_pools_.size(); ++i) {
     const auto & pool = proxy_pools_[i].io_pool_;

--- a/cpp/arcae/table_factory.h
+++ b/cpp/arcae/table_factory.h
@@ -11,15 +11,16 @@
 namespace arcae {
 
 arrow::Result<std::shared_ptr<NewTableProxy>>
-OpenTable(const std::string &filename, bool readonly = true,
+OpenTable(const std::string &filename,
+          std::size_t ninstances = 1,
+          bool readonly = true,
           const std::string &json_lockoptions = R"({"option": "auto"})");
 arrow::Result<std::shared_ptr<NewTableProxy>>
 DefaultMS(const std::string &name, const std::string &subtable = "MAIN",
           const std::string &json_table_desc = "{}",
           const std::string &json_dminfo = "{}");
 arrow::Result<std::shared_ptr<NewTableProxy>>
-Taql(const std::string &taql,
-     const std::vector<std::shared_ptr<NewTableProxy>> &tables = {});
+Taql(const std::string &taql, const std::vector<std::shared_ptr<NewTableProxy>> &tables = {});
 
 } // namespace arcae
 

--- a/src/arcae/__init__.py
+++ b/src/arcae/__init__.py
@@ -23,8 +23,8 @@ if PYTHON_CASACORE_FOUND and not COEXIST_WITH_PYTHON_CASACORE:
         "continue regardless.")
 
 
-def table(filename: str, readonly: bool = True, lockoptions: Union[str, dict] = "auto") -> "Table":
+def table(filename: str, ninstances: int = 1, readonly: bool = True, lockoptions: Union[str, dict] = "auto") -> "Table":
     # Defer cython module import, to avoid conflicts between arcae casacore libraries
     # and python-casacore casacore libraries
     from arcae.lib.arrow_tables import Table
-    return Table.from_filename(filename, readonly, lockoptions)
+    return Table.from_filename(filename, ninstances, readonly, lockoptions)

--- a/src/arcae/arrow_tables.pxd
+++ b/src/arcae/arrow_tables.pxd
@@ -79,6 +79,7 @@ cdef extern from "arcae/new_table_proxy.h" namespace "arcae" nogil:
 cdef extern from "arcae/table_factory.h" namespace "arcae" nogil:
     cdef CResult[shared_ptr[CCasaTable]] COpenTable" arcae::OpenTable"(
                                                     const string & filename,
+                                                    size_t ninstances,
                                                     bool readonly,
                                                     const string & json_lockoptions)
     cdef CResult[shared_ptr[CCasaTable]] CDefaultMS" arcae::DefaultMS"(

--- a/src/arcae/arrow_tables.pyx
+++ b/src/arcae/arrow_tables.pyx
@@ -139,8 +139,10 @@ cdef class Table:
         return table
 
     @staticmethod
-    def from_filename(filename: str, readonly: bool = True, lockoptions: Union[str, dict] = "auto") -> Table:
-        cdef string cfilename = tobytes(filename)
+    def from_filename(filename: str, ninstances: int = 1, readonly: bool = True, lockoptions: Union[str, dict] = "auto") -> Table:
+        cdef:
+            string cfilename = tobytes(filename)
+            size_t cninstances = ninstances
 
         cdef Table table = Table.__new__(Table)
         if isinstance(lockoptions, str):
@@ -153,7 +155,7 @@ cdef class Table:
         clockoptions: string = tobytes(lockoptions)
 
         with nogil:
-            table.c_table = GetResultValue(COpenTable(cfilename, readonly, clockoptions))
+            table.c_table = GetResultValue(COpenTable(cfilename, cninstances, readonly, clockoptions))
         return table
 
     @staticmethod


### PR DESCRIPTION
IsolatedTableProxy objects can now open multiple Table instances. I/O operations are multiplexed over these instances using a crude round robin strategy, based on the number of tasks in the associated I/O thread pools.