### PR TITLE
Disable OpenBLAS threading

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 X.Y.Z (YYYY-MM-DD)
 ------------------
+* Disable OpenBLAS threading (:pr:`117`)
 * Move Cython source to lib directory (:pr:`116`)
 * Upgrade to pyarrow 16.1.0 (:pr:`115`)
 * Code formatting nits (:pr:`114`)

--- a/vcpkg/overlay-ports/casacore/vcpkg.json
+++ b/vcpkg/overlay-ports/casacore/vcpkg.json
@@ -5,11 +5,14 @@
   "homepage": "https://casacore.github.io/",
   "supports": "!windows",
   "dependencies": [
-    "blas",
     "boost-filesystem",
     "cfitsio",
     "gsl",
     "lapack",
+    {
+      "name": "openblas",
+      "default-features": false
+    },
     {
       "name": "vcpkg-cmake",
       "host": true


### PR DESCRIPTION
Selecting openblas as follows

```json
{
  "name": "openblas",
  "default-features": false,
}
```

turns off all features of the library (i.e. `simplethreads` and `threads`)