### PR TITLE
Use conda forge compilers on MACOSX and update MACOX_DEPLOYMENT_TARGET=12.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ env:
   # Install conda-forge compilers and llvm-openmp
   CIBW_BEFORE_ALL_MACOS: |
     curl -L -O "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh"
-    bash Miniforge3-$(uname)-$(uname -m).sh
+    bash Miniforge3-$(uname)-$(uname -m).sh -b
     mambda create -n arcae-build -c conda-forge compilers llvm-openmp python
   CIBW_BEFORE_BUILD_MACOS: |
     mamba activate arcae-build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,7 +193,9 @@ jobs:
               -w {dest_dir} \
               -v {wheel} \
               --exclude libarrow_python.dylib \
-              --exclude libarrow.1601.dylib
+              --exclude libarrow.1601.dylib \
+              --ignore-missing-dependencies
+
       - name: Upload wheel artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,13 +17,10 @@ env:
   CIBW_BEFORE_ALL_MACOS: |
     curl -L -O "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh"
     bash Miniforge3-$(uname)-$(uname -m).sh -b -p "$HOME/conda"
-    source "${HOME}/conda/etc/profile.d/conda.sh"
-    conda activate
-    mamba create -n arcae-build -c conda-forge compilers llvm-openmp python
   CIBW_BEFORE_BUILD_MACOS: |
     source "${HOME}/conda/etc/profile.d/conda.sh"
-    conda activate
-    mamba activate arcae-build
+    conda create -n arcae-build -c conda-forge compilers llvm-openmp python
+    conda activate arcae-build
   CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/manylinux_2_28_x86_64
   CIBW_TEST_EXTRAS_LINUX: applications,test
   CIBW_TEST_COMMAND_LINUX: py.test -s -vvv --pyargs arcae

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,21 +17,11 @@ env:
   CIBW_BEFORE_ALL_MACOS: |
     curl -L -O "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh"
     bash Miniforge3-$(uname)-$(uname -m).sh -b -p "$HOME/conda"
-    source "${HOME}/conda/etc/profile.d/conda.sh"
     source "${HOME}/conda/etc/profile.d/mamba.sh"
-    conda activate
     mamba create -n arcae-build -c conda-forge compilers llvm-openmp python
   CIBW_BEFORE_BUILD_MACOS: |
-    source "${HOME}/conda/etc/profile.d/conda.sh"
     source "${HOME}/conda/etc/profile.d/mamba.sh"
-    conda activate
     mamba activate arcae-build
-  CIBW_BEFORE_TEST_MACOS: |
-    mamba init --reverse
-    CONDA_BASE_ENVIRONMENT=$(mamba info --base)
-    rm -rf ${CONDA_BASE_ENVIRONMENT}
-    rm -f "${HOME}/.condarc"
-    rm -fr ${HOME}/.conda
   CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/manylinux_2_28_x86_64
   CIBW_TEST_EXTRAS_LINUX: applications,test
   CIBW_TEST_COMMAND_LINUX: py.test -s -vvv --pyargs arcae

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,9 +193,7 @@ jobs:
               -w {dest_dir} \
               -v {wheel} \
               --exclude libarrow_python.dylib \
-              --exclude libarrow.1601.dylib \
-              --ignore-missing-dependencies
-
+              --exclude libarrow.1601.dylib
       - name: Upload wheel artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,12 +18,10 @@ env:
     curl -L -O "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh"
     bash Miniforge3-$(uname)-$(uname -m).sh -b -p "$HOME/conda"
     source "${HOME}/conda/etc/profile.d/conda.sh"
-    source "${HOME}/conda/etc/profile.d/mamba.sh"
     conda activate
     mamba create -n arcae-build -c conda-forge compilers llvm-openmp python
   CIBW_BEFORE_BUILD_MACOS: |
     source "${HOME}/conda/etc/profile.d/conda.sh"
-    source "${HOME}/conda/etc/profile.d/mamba.sh"
     conda activate
     mamba activate arcae-build
   CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/manylinux_2_28_x86_64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,6 @@ env:
   CIBW_BEFORE_ALL_LINUX: yum install -y zip flex bison gcc-gfortran
   # Install conda-forge compilers and llvm-openmp
   CIBW_BEFORE_ALL_MACOS: |
-    xcode-select --install
     curl -L -O "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh"
     bash Miniforge3-$(uname)-$(uname -m).sh
     mambda create -n arcae-build -c conda-forge compilers llvm-openmp python

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,14 +13,14 @@ on:
 env:
   CIBW_BUILD_FRONTEND: build
   CIBW_BEFORE_ALL_LINUX: yum install -y zip flex bison gcc-gfortran
-  # Need to reinstall gcc in order to get gfortran
+  # Install conda-forge compilers and llvm-openmp
   CIBW_BEFORE_ALL_MACOS: |
-    brew install python llvm
-    brew reinstall gcc
+    xcode-select --install
+    curl -L -O "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh"
+    bash Miniforge3-$(uname)-$(uname -m).sh
+    mambda create -n arcae-build -c conda-forge compilers llvm-openmp python
   CIBW_BEFORE_BUILD_MACOS: |
-    export PATH="/opt/homebrew/opt/llvm/bin:$PATH"
-    export LDFLAGS="-L/opt/homebrew/opt/llvm/lib"
-    export CPPFLAGS="-I/opt/homebrew/opt/llvm/include"
+    mamba activate arcae-build
   CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/manylinux_2_28_x86_64
   CIBW_TEST_EXTRAS_LINUX: applications,test
   CIBW_TEST_COMMAND_LINUX: py.test -s -vvv --pyargs arcae

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,15 @@ env:
   # Install conda-forge compilers and llvm-openmp
   CIBW_BEFORE_ALL_MACOS: |
     curl -L -O "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh"
-    bash Miniforge3-$(uname)-$(uname -m).sh -b
+    bash Miniforge3-$(uname)-$(uname -m).sh -b -p "$HOME/conda"
+    source "${HOME}/conda/etc/profile.d/conda.sh"
+    source "${HOME}/conda/etc/profile.d/mamba.sh"
+    conda activate
     micromamba create -n arcae-build -c conda-forge compilers llvm-openmp python
   CIBW_BEFORE_BUILD_MACOS: |
+    source "${HOME}/conda/etc/profile.d/conda.sh"
+    source "${HOME}/conda/etc/profile.d/mamba.sh"
+    conda activate
     micromamba activate arcae-build
   CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/manylinux_2_28_x86_64
   CIBW_TEST_EXTRAS_LINUX: applications,test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,12 +20,12 @@ env:
     source "${HOME}/conda/etc/profile.d/conda.sh"
     source "${HOME}/conda/etc/profile.d/mamba.sh"
     conda activate
-    micromamba create -n arcae-build -c conda-forge compilers llvm-openmp python
+    mamba create -n arcae-build -c conda-forge compilers llvm-openmp python
   CIBW_BEFORE_BUILD_MACOS: |
     source "${HOME}/conda/etc/profile.d/conda.sh"
     source "${HOME}/conda/etc/profile.d/mamba.sh"
     conda activate
-    micromamba activate arcae-build
+    mamba activate arcae-build
   CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/manylinux_2_28_x86_64
   CIBW_TEST_EXTRAS_LINUX: applications,test
   CIBW_TEST_COMMAND_LINUX: py.test -s -vvv --pyargs arcae

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,7 +180,7 @@ jobs:
           CIBW_ENVIRONMENT_LINUX: ${{ env.CIBW_ENVIRONMENT_COMMON }}
           CIBW_ENVIRONMENT_MACOS: >
             ${{ env.CIBW_ENVIRONMENT_COMMON }}
-            MACOSX_DEPLOYMENT_TARGET=11.0
+            MACOSX_DEPLOYMENT_TARGET=12.0
           CIBW_REPAIR_WHEEL_COMMAND_LINUX: >
             auditwheel repair
             -w {dest_dir} {wheel}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,12 @@ env:
     source "${HOME}/conda/etc/profile.d/mamba.sh"
     conda activate
     mamba activate arcae-build
+  CIBW_BEFORE_TEST_MACOS: |
+    mamba init --reverse
+    CONDA_BASE_ENVIRONMENT=$(mamba info --base)
+    rm -rf ${CONDA_BASE_ENVIRONMENT}
+    rm -f "${HOME}/.condarc"
+    rm -fr ${HOME}/.conda
   CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/manylinux_2_28_x86_64
   CIBW_TEST_EXTRAS_LINUX: applications,test
   CIBW_TEST_COMMAND_LINUX: py.test -s -vvv --pyargs arcae

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,11 @@ on:
 env:
   CIBW_BUILD_FRONTEND: build
   CIBW_BEFORE_ALL_LINUX: yum install -y zip flex bison gcc-gfortran
-  # Install conda-forge compilers and llvm-openmp
+  # Install miniforge
   CIBW_BEFORE_ALL_MACOS: |
     curl -L -O "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh"
     bash Miniforge3-$(uname)-$(uname -m).sh -b -p "$HOME/conda"
+  # Install conda-forge compilers and llvm-openmp
   CIBW_BEFORE_BUILD_MACOS: |
     source "${HOME}/conda/etc/profile.d/conda.sh"
     conda create -n arcae-build -c conda-forge compilers llvm-openmp python

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,9 @@ env:
   CIBW_BEFORE_ALL_MACOS: |
     curl -L -O "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh"
     bash Miniforge3-$(uname)-$(uname -m).sh -b
-    mambda create -n arcae-build -c conda-forge compilers llvm-openmp python
+    micromamba create -n arcae-build -c conda-forge compilers llvm-openmp python
   CIBW_BEFORE_BUILD_MACOS: |
-    mamba activate arcae-build
+    micromamba activate arcae-build
   CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/manylinux_2_28_x86_64
   CIBW_TEST_EXTRAS_LINUX: applications,test
   CIBW_TEST_COMMAND_LINUX: py.test -s -vvv --pyargs arcae

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,14 @@ env:
   CIBW_BEFORE_ALL_MACOS: |
     curl -L -O "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh"
     bash Miniforge3-$(uname)-$(uname -m).sh -b -p "$HOME/conda"
+    source "${HOME}/conda/etc/profile.d/conda.sh"
     source "${HOME}/conda/etc/profile.d/mamba.sh"
+    conda activate
     mamba create -n arcae-build -c conda-forge compilers llvm-openmp python
   CIBW_BEFORE_BUILD_MACOS: |
+    source "${HOME}/conda/etc/profile.d/conda.sh"
     source "${HOME}/conda/etc/profile.d/mamba.sh"
+    conda activate
     mamba activate arcae-build
   CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/manylinux_2_28_x86_64
   CIBW_TEST_EXTRAS_LINUX: applications,test

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 X.Y.Z (DD-MM-YYYY)
 ------------------
+* Use conda forge compilers on MACOSX and update MACOX_DEPLOYMENT_TARGET=12.0 (:pr:`131`)
 * Avoid sorting sorted indices (:pr:`129`, :pr:`130`)
 
 0.2.5 (04-10-2024)


### PR DESCRIPTION
- Closes #99 

This PR changes the MACOSX build process to use the conda compilers, instead of the homebrew compilers. This means that t\`libgfortran.dylib` and `libquadmath.dylib` libraries  appropriate to the MACOS_DEPLOYMENT_TARGET are included in the MACOSX wheel.

Additionally, the MACOSX_DEPLOYMENT_TARGET has been raised to 12.0

