### PR TITLE
Disable use of github actions cache by vcpkg

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,6 +170,7 @@ jobs:
             export PATH="/opt/homebrew/opt/llvm/bin:$PATH"
             export LDFLAGS="-L/opt/homebrew/opt/llvm/lib"
             export CPPFLAGS="-I/opt/homebrew/opt/llvm/include"
+          CIBW_CONTAINER_ENGINE: "docker; create_args: --network=host"
           CIBW_ENVIRONMENT: ${{ env.CIBW_ENVIRONMENT_COMMON }}
           CIBW_ENVIRONMENT_MACOS: >
             ${{ env.CIBW_ENVIRONMENT_COMMON }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,9 +57,6 @@ jobs:
         with:
           python-version: ${{ env.HOST_PYTHON_VERSION }}
 
-      - name: Expose GitHub Runtime
-        uses: crazy-max/ghaction-github-runtime@v3
-
       - name: List directory structure
         run: tree
 
@@ -72,7 +69,6 @@ jobs:
 
       - name: Build C++ libraries and tests
         env:
-          VCPKG_BINARY_SOURCES: clear;x-gha,readwrite
           VCPKG_TARGET_TRIPLET: ${{ env.VCPKG_TARGET_TRIPLET }}
         run: |
           cmake -S . -B build
@@ -141,16 +137,10 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@v4
 
-      - name: Expose GitHub Runtime
-        uses: crazy-max/ghaction-github-runtime@v3
-
       - name: Set Common Build Environment Variable
         env:
           COMMON_ENV: >
             CMAKE_ARGS=-DBUILD_TESTING=OFF
-            ACTIONS_CACHE_URL=${{ env.ACTIONS_CACHE_URL }}
-            ACTIONS_RUNTIME_TOKEN=${{ env.ACTIONS_RUNTIME_TOKEN }}
-            VCPKG_BINARY_SOURCES="clear;x-gha,readwrite"
             VCPKG_FORCE_SYSTEM_BINARIES=1
             VCPKG_TARGET_TRIPLET=${{ matrix.triplet }}
             VCPKG_INSTALLED_DIR=${{ env.VCPKG_INSTALLED_DIR }}
@@ -170,7 +160,6 @@ jobs:
             export PATH="/opt/homebrew/opt/llvm/bin:$PATH"
             export LDFLAGS="-L/opt/homebrew/opt/llvm/lib"
             export CPPFLAGS="-I/opt/homebrew/opt/llvm/include"
-          CIBW_CONTAINER_ENGINE: "docker; create_args: --network=host"
           CIBW_ENVIRONMENT: ${{ env.CIBW_ENVIRONMENT_COMMON }}
           CIBW_ENVIRONMENT_MACOS: >
             ${{ env.CIBW_ENVIRONMENT_COMMON }}

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 X.Y.Z (DD-MM-YYYY)
 ------------------
+* Disable use of github actions cache by vcpkg (:pr:`152`)
 * Upgrade to C++20 (:pr:`150`)
 * Upgrade to cibuildwheel 2.23.3 (:pr:`149`)
 * Slight loop optimisation (:pr:`147`, :pr:`148`)


### PR DESCRIPTION
vcpkg's curl invocations are timing out when invoked inside the CIBW container, due to the deprecation of the github actions cache

- https://github.com/microsoft/vcpkg/issues/45073
