### PR TITLE
Set host python version to 3.12 in github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
     - cron: '30 2 * * 1,4' # Every Monday and Thursday @ 2h30am UTC
 
 env:
-  HOST_PYTHON_VERSION: "3.10"
+  HOST_PYTHON_VERSION: "3.12"
   VCPKG_INSTALLED_DIR: /tmp/vcpkg_installed
   ARTIFACT_NAME: wheel
 


### PR DESCRIPTION
Existing host python version is 3.10 and the following technically requires at least 3.11 according to the release notes.

- #155 