### PR TITLE
Impute missing rows from the result shape

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,9 +79,9 @@ jobs:
           cd build
           ctest --verbose
 
-      # - name: Debug with tmate on failure
-      #   if: ${{ failure() }}
-      #   uses: mxschmitt/action-tmate@v3
+      - name: Debug with tmate on failure
+        if: ${{ failure() }}
+        uses: mxschmitt/action-tmate@v3
 
 
   build-wheels:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,173 +74,171 @@ jobs:
           cmake -S . -B build
           cmake --build build
 
-      - name: Execute C++ tests
-        run: |
-          cd build
-          ctest --verbose
+      - name: Fail
+        run: exit 1
 
       - name: Debug with tmate on failure
         if: ${{ failure() }}
         uses: mxschmitt/action-tmate@v3
 
 
-  build-wheels:
-    name: Build wheel for ${{ matrix.cpython }}-${{ matrix.os_short }}-${{ matrix.arch }}
-    runs-on: ${{ matrix.os }}
-    if: "!contains(github.event.head_commit.message, '[skip ci]')"
-    strategy:
-      fail-fast: false
-      matrix:
-        os: ["ubuntu-22.04", "macos-13", "macos-14", "ubuntu-22.04-arm"]
-        # https://peps.python.org/pep-0425
-        cpython: ["cp310", "cp311", "cp312", "cp313"]
-        is_main_or_release:
-          - ${{ contains(github.ref, 'main') || startsWith(github.ref, 'refs/tags')}}
-        # Avoid building all wheels in a PR
-        exclude:
-          - is_main_or_release: false
-            cpython: cp310
-          - is_main_or_release: false
-            cpython: cp311
-          - is_main_or_release: false
-            cpython: cp312
-        include:
-          - os: ubuntu-22.04
-            os_short: linux
-            arch: "x86_64"
-            triplet: "x64-linux-dynamic-cxx20-abi1-rel"
-            extra_build: "manylinux_x86_64"
-          - os: ubuntu-22.04-arm
-            os_short: linux
-            arch: "aarch64"
-            triplet: "arm64-linux-dynamic-cxx20-abi1-rel"
-            extra_build: "manylinux_aarch64"
-          - os: macos-13
-            os_short: macos
-            arch: "x86_64"
-            deployment_target: "13.0"
-            triplet: "x64-osx-dynamic-cxx20-abi1-rel"
-            extra_build: "macosx_x86_64"
-          - os: macos-14
-            os_short: macos
-            arch: "arm64"
-            deployment_target: "14.0"
-            triplet: "arm64-osx-dynamic-cxx20-abi1-rel"
-            extra_build: "macosx_arm64"
-    steps:
-      - name: Set up Python ${{ env.HOST_PYTHON_VERSION }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ env.HOST_PYTHON_VERSION }}
+  # build-wheels:
+  #   name: Build wheel for ${{ matrix.cpython }}-${{ matrix.os_short }}-${{ matrix.arch }}
+  #   runs-on: ${{ matrix.os }}
+  #   if: "!contains(github.event.head_commit.message, '[skip ci]')"
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       os: ["ubuntu-22.04", "macos-13", "macos-14", "ubuntu-22.04-arm"]
+  #       # https://peps.python.org/pep-0425
+  #       cpython: ["cp310", "cp311", "cp312", "cp313"]
+  #       is_main_or_release:
+  #         - ${{ contains(github.ref, 'main') || startsWith(github.ref, 'refs/tags')}}
+  #       # Avoid building all wheels in a PR
+  #       exclude:
+  #         - is_main_or_release: false
+  #           cpython: cp310
+  #         - is_main_or_release: false
+  #           cpython: cp311
+  #         - is_main_or_release: false
+  #           cpython: cp312
+  #       include:
+  #         - os: ubuntu-22.04
+  #           os_short: linux
+  #           arch: "x86_64"
+  #           triplet: "x64-linux-dynamic-cxx20-abi1-rel"
+  #           extra_build: "manylinux_x86_64"
+  #         - os: ubuntu-22.04-arm
+  #           os_short: linux
+  #           arch: "aarch64"
+  #           triplet: "arm64-linux-dynamic-cxx20-abi1-rel"
+  #           extra_build: "manylinux_aarch64"
+  #         - os: macos-13
+  #           os_short: macos
+  #           arch: "x86_64"
+  #           deployment_target: "13.0"
+  #           triplet: "x64-osx-dynamic-cxx20-abi1-rel"
+  #           extra_build: "macosx_x86_64"
+  #         - os: macos-14
+  #           os_short: macos
+  #           arch: "arm64"
+  #           deployment_target: "14.0"
+  #           triplet: "arm64-osx-dynamic-cxx20-abi1-rel"
+  #           extra_build: "macosx_arm64"
+  #   steps:
+  #     - name: Set up Python ${{ env.HOST_PYTHON_VERSION }}
+  #       uses: actions/setup-python@v5
+  #       with:
+  #         python-version: ${{ env.HOST_PYTHON_VERSION }}
 
-      - name: Upgrade pip and install virtualenv
-        run: python -m pip install -U pip virtualenv
+  #     - name: Upgrade pip and install virtualenv
+  #       run: python -m pip install -U pip virtualenv
 
-      - name: Checkout source
-        uses: actions/checkout@v5
+  #     - name: Checkout source
+  #       uses: actions/checkout@v5
 
-      - name: Set Common Build Environment Variable
-        env:
-          COMMON_ENV: >
-            CMAKE_ARGS=-DBUILD_TESTING=OFF
-            VCPKG_FORCE_SYSTEM_BINARIES=1
-            VCPKG_TARGET_TRIPLET=${{ matrix.triplet }}
-            VCPKG_INSTALLED_DIR=${{ env.VCPKG_INSTALLED_DIR }}
-            LD_LIBRARY_PATH=${{ env.VCPKG_INSTALLED_DIR }}/${{ matrix.triplet }}/lib
-        run: echo "CIBW_ENVIRONMENT_COMMON=$COMMON_ENV" >> $GITHUB_ENV
+  #     - name: Set Common Build Environment Variable
+  #       env:
+  #         COMMON_ENV: >
+  #           CMAKE_ARGS=-DBUILD_TESTING=OFF
+  #           VCPKG_FORCE_SYSTEM_BINARIES=1
+  #           VCPKG_TARGET_TRIPLET=${{ matrix.triplet }}
+  #           VCPKG_INSTALLED_DIR=${{ env.VCPKG_INSTALLED_DIR }}
+  #           LD_LIBRARY_PATH=${{ env.VCPKG_INSTALLED_DIR }}/${{ matrix.triplet }}/lib
+  #       run: echo "CIBW_ENVIRONMENT_COMMON=$COMMON_ENV" >> $GITHUB_ENV
 
-      - name: Run cibuildwheel
-        env:
-          CIBW_BUILD: ${{ matrix.cpython }}-${{ matrix.extra_build }}
-          CIBW_BUILD_FRONTEND: build
-          CIBW_ARCHS: ${{ matrix.arch }}
-          CIBW_BEFORE_ALL_LINUX: yum install -y zip flex bison gcc-gfortran
-          CIBW_BEFORE_ALL_MACOS: |
-            brew install python llvm
-            brew reinstall gcc
-          CIBW_BEFORE_BUILD_MACOS: |
-            export PATH="/opt/homebrew/opt/llvm/bin:$PATH"
-            export LDFLAGS="-L/opt/homebrew/opt/llvm/lib"
-            export CPPFLAGS="-I/opt/homebrew/opt/llvm/include"
-          CIBW_ENVIRONMENT: ${{ env.CIBW_ENVIRONMENT_COMMON }}
-          CIBW_ENVIRONMENT_MACOS: >
-            ${{ env.CIBW_ENVIRONMENT_COMMON }}
-            MACOSX_DEPLOYMENT_TARGET=${{ matrix.deployment_target }}
-          CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/manylinux_2_28_x86_64
-          CIBW_MANYLINUX_AARCH64_IMAGE: quay.io/pypa/manylinux_2_28_aarch64
-          CIBW_TEST_EXTRAS_LINUX: applications,test
-          CIBW_TEST_COMMAND: bash {package}/ci/scripts/run_tests.sh
-          CIBW_REPAIR_WHEEL_COMMAND_LINUX: >
-            auditwheel repair
-            -w {dest_dir} {wheel}
-            --exclude libarrow_python.so.2100
-            --exclude libarrow.so.2100
-          CIBW_REPAIR_WHEEL_COMMAND_MACOS: |
-            DYLD_LIBRARY_PATH=$LD_LIBRARY_PATH delocate-listdeps {wheel}
-            DYLD_LIBRARY_PATH=$LD_LIBRARY_PATH delocate-wheel \
-              --require-archs {delocate_archs} \
-              -w {dest_dir} \
-              -v {wheel} \
-              --exclude libarrow_python.2100.dylib \
-              --exclude libarrow.2100.dylib \
-              --ignore-missing-dependencies
-        uses: pypa/cibuildwheel@v3.1.4
+  #     - name: Run cibuildwheel
+  #       env:
+  #         CIBW_BUILD: ${{ matrix.cpython }}-${{ matrix.extra_build }}
+  #         CIBW_BUILD_FRONTEND: build
+  #         CIBW_ARCHS: ${{ matrix.arch }}
+  #         CIBW_BEFORE_ALL_LINUX: yum install -y zip flex bison gcc-gfortran
+  #         CIBW_BEFORE_ALL_MACOS: |
+  #           brew install python llvm
+  #           brew reinstall gcc
+  #         CIBW_BEFORE_BUILD_MACOS: |
+  #           export PATH="/opt/homebrew/opt/llvm/bin:$PATH"
+  #           export LDFLAGS="-L/opt/homebrew/opt/llvm/lib"
+  #           export CPPFLAGS="-I/opt/homebrew/opt/llvm/include"
+  #         CIBW_ENVIRONMENT: ${{ env.CIBW_ENVIRONMENT_COMMON }}
+  #         CIBW_ENVIRONMENT_MACOS: >
+  #           ${{ env.CIBW_ENVIRONMENT_COMMON }}
+  #           MACOSX_DEPLOYMENT_TARGET=${{ matrix.deployment_target }}
+  #         CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/manylinux_2_28_x86_64
+  #         CIBW_MANYLINUX_AARCH64_IMAGE: quay.io/pypa/manylinux_2_28_aarch64
+  #         CIBW_TEST_EXTRAS_LINUX: applications,test
+  #         CIBW_TEST_COMMAND: bash {package}/ci/scripts/run_tests.sh
+  #         CIBW_REPAIR_WHEEL_COMMAND_LINUX: >
+  #           auditwheel repair
+  #           -w {dest_dir} {wheel}
+  #           --exclude libarrow_python.so.2100
+  #           --exclude libarrow.so.2100
+  #         CIBW_REPAIR_WHEEL_COMMAND_MACOS: |
+  #           DYLD_LIBRARY_PATH=$LD_LIBRARY_PATH delocate-listdeps {wheel}
+  #           DYLD_LIBRARY_PATH=$LD_LIBRARY_PATH delocate-wheel \
+  #             --require-archs {delocate_archs} \
+  #             -w {dest_dir} \
+  #             -v {wheel} \
+  #             --exclude libarrow_python.2100.dylib \
+  #             --exclude libarrow.2100.dylib \
+  #             --ignore-missing-dependencies
+  #       uses: pypa/cibuildwheel@v3.1.4
 
-      - name: Upload wheel artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ env.ARTIFACT_NAME }}-${{ matrix.os_short }}-${{ matrix.cpython }}-${{ matrix.arch }}
-          path: ./wheelhouse/*.whl
+  #     - name: Upload wheel artifacts
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: ${{ env.ARTIFACT_NAME }}-${{ matrix.os_short }}-${{ matrix.cpython }}-${{ matrix.arch }}
+  #         path: ./wheelhouse/*.whl
 
-      # - name: Debug with tmate on failure
-      #   if: ${{ failure() }}
-      #   uses: mxschmitt/action-tmate@v3
+  #     # - name: Debug with tmate on failure
+  #     #   if: ${{ failure() }}
+  #     #   uses: mxschmitt/action-tmate@v3
 
-  upload-to-test-pypi:
-    name: Upload release to Test PyPI
-    needs: [build-sdist, build-wheels]
-    runs-on: ubuntu-latest
-    environment:
-      name: release-test
-    permissions:
-      id-token: write
-    steps:
-      - name: Download distribution artifacts
-        uses: actions/download-artifact@v5
-        with:
-          pattern: ${{ env.ARTIFACT_NAME }}-*
-          merge-multiple: true
-          path: dist
+  # upload-to-test-pypi:
+  #   name: Upload release to Test PyPI
+  #   needs: [build-sdist, build-wheels]
+  #   runs-on: ubuntu-latest
+  #   environment:
+  #     name: release-test
+  #   permissions:
+  #     id-token: write
+  #   steps:
+  #     - name: Download distribution artifacts
+  #       uses: actions/download-artifact@v5
+  #       with:
+  #         pattern: ${{ env.ARTIFACT_NAME }}-*
+  #         merge-multiple: true
+  #         path: dist
 
-      - name: List artifacts
-        run: ls -lh dist
+  #     - name: List artifacts
+  #       run: ls -lh dist
 
-      - name: Publish package distributions to Test PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          repository-url: https://test.pypi.org/legacy/
-          skip-existing: true
-        continue-on-error: true
+  #     - name: Publish package distributions to Test PyPI
+  #       uses: pypa/gh-action-pypi-publish@release/v1
+  #       with:
+  #         repository-url: https://test.pypi.org/legacy/
+  #         skip-existing: true
+  #       continue-on-error: true
 
-  upload-to-pypi:
-    name: Upload release to PyPI
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
-    needs: [build-sdist, build-wheels]
-    runs-on: ubuntu-latest
-    environment:
-      name: release
-    permissions:
-      id-token: write
-    steps:
-      - name: Download distribution artifacts
-        uses: actions/download-artifact@v5
-        with:
-          pattern: ${{ env.ARTIFACT_NAME }}-*
-          merge-multiple: true
-          path: dist
+  # upload-to-pypi:
+  #   name: Upload release to PyPI
+  #   if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+  #   needs: [build-sdist, build-wheels]
+  #   runs-on: ubuntu-latest
+  #   environment:
+  #     name: release
+  #   permissions:
+  #     id-token: write
+  #   steps:
+  #     - name: Download distribution artifacts
+  #       uses: actions/download-artifact@v5
+  #       with:
+  #         pattern: ${{ env.ARTIFACT_NAME }}-*
+  #         merge-multiple: true
+  #         path: dist
 
-      - name: List artifacts
-        run: ls -lh dist
+  #     - name: List artifacts
+  #       run: ls -lh dist
 
-      - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+  #     - name: Publish package distributions to PyPI
+  #       uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,163 +82,163 @@ jobs:
         uses: mxschmitt/action-tmate@v3
 
 
-  # build-wheels:
-  #   name: Build wheel for ${{ matrix.cpython }}-${{ matrix.os_short }}-${{ matrix.arch }}
-  #   runs-on: ${{ matrix.os }}
-  #   if: "!contains(github.event.head_commit.message, '[skip ci]')"
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       os: ["ubuntu-22.04", "macos-13", "macos-14", "ubuntu-22.04-arm"]
-  #       # https://peps.python.org/pep-0425
-  #       cpython: ["cp310", "cp311", "cp312", "cp313"]
-  #       is_main_or_release:
-  #         - ${{ contains(github.ref, 'main') || startsWith(github.ref, 'refs/tags')}}
-  #       # Avoid building all wheels in a PR
-  #       exclude:
-  #         - is_main_or_release: false
-  #           cpython: cp310
-  #         - is_main_or_release: false
-  #           cpython: cp311
-  #         - is_main_or_release: false
-  #           cpython: cp312
-  #       include:
-  #         - os: ubuntu-22.04
-  #           os_short: linux
-  #           arch: "x86_64"
-  #           triplet: "x64-linux-dynamic-cxx20-abi1-rel"
-  #           extra_build: "manylinux_x86_64"
-  #         - os: ubuntu-22.04-arm
-  #           os_short: linux
-  #           arch: "aarch64"
-  #           triplet: "arm64-linux-dynamic-cxx20-abi1-rel"
-  #           extra_build: "manylinux_aarch64"
-  #         - os: macos-13
-  #           os_short: macos
-  #           arch: "x86_64"
-  #           deployment_target: "13.0"
-  #           triplet: "x64-osx-dynamic-cxx20-abi1-rel"
-  #           extra_build: "macosx_x86_64"
-  #         - os: macos-14
-  #           os_short: macos
-  #           arch: "arm64"
-  #           deployment_target: "14.0"
-  #           triplet: "arm64-osx-dynamic-cxx20-abi1-rel"
-  #           extra_build: "macosx_arm64"
-  #   steps:
-  #     - name: Set up Python ${{ env.HOST_PYTHON_VERSION }}
-  #       uses: actions/setup-python@v5
-  #       with:
-  #         python-version: ${{ env.HOST_PYTHON_VERSION }}
+  build-wheels:
+    name: Build wheel for ${{ matrix.cpython }}-${{ matrix.os_short }}-${{ matrix.arch }}
+    runs-on: ${{ matrix.os }}
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["ubuntu-22.04", "macos-13", "macos-14", "ubuntu-22.04-arm"]
+        # https://peps.python.org/pep-0425
+        cpython: ["cp310", "cp311", "cp312", "cp313"]
+        is_main_or_release:
+          - ${{ contains(github.ref, 'main') || startsWith(github.ref, 'refs/tags')}}
+        # Avoid building all wheels in a PR
+        exclude:
+          - is_main_or_release: false
+            cpython: cp310
+          - is_main_or_release: false
+            cpython: cp311
+          - is_main_or_release: false
+            cpython: cp312
+        include:
+          - os: ubuntu-22.04
+            os_short: linux
+            arch: "x86_64"
+            triplet: "x64-linux-dynamic-cxx20-abi1-rel"
+            extra_build: "manylinux_x86_64"
+          - os: ubuntu-22.04-arm
+            os_short: linux
+            arch: "aarch64"
+            triplet: "arm64-linux-dynamic-cxx20-abi1-rel"
+            extra_build: "manylinux_aarch64"
+          - os: macos-13
+            os_short: macos
+            arch: "x86_64"
+            deployment_target: "13.0"
+            triplet: "x64-osx-dynamic-cxx20-abi1-rel"
+            extra_build: "macosx_x86_64"
+          - os: macos-14
+            os_short: macos
+            arch: "arm64"
+            deployment_target: "14.0"
+            triplet: "arm64-osx-dynamic-cxx20-abi1-rel"
+            extra_build: "macosx_arm64"
+    steps:
+      - name: Set up Python ${{ env.HOST_PYTHON_VERSION }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.HOST_PYTHON_VERSION }}
 
-  #     - name: Upgrade pip and install virtualenv
-  #       run: python -m pip install -U pip virtualenv
+      - name: Upgrade pip and install virtualenv
+        run: python -m pip install -U pip virtualenv
 
-  #     - name: Checkout source
-  #       uses: actions/checkout@v5
+      - name: Checkout source
+        uses: actions/checkout@v5
 
-  #     - name: Set Common Build Environment Variable
-  #       env:
-  #         COMMON_ENV: >
-  #           CMAKE_ARGS=-DBUILD_TESTING=OFF
-  #           VCPKG_FORCE_SYSTEM_BINARIES=1
-  #           VCPKG_TARGET_TRIPLET=${{ matrix.triplet }}
-  #           VCPKG_INSTALLED_DIR=${{ env.VCPKG_INSTALLED_DIR }}
-  #           LD_LIBRARY_PATH=${{ env.VCPKG_INSTALLED_DIR }}/${{ matrix.triplet }}/lib
-  #       run: echo "CIBW_ENVIRONMENT_COMMON=$COMMON_ENV" >> $GITHUB_ENV
+      - name: Set Common Build Environment Variable
+        env:
+          COMMON_ENV: >
+            CMAKE_ARGS=-DBUILD_TESTING=OFF
+            VCPKG_FORCE_SYSTEM_BINARIES=1
+            VCPKG_TARGET_TRIPLET=${{ matrix.triplet }}
+            VCPKG_INSTALLED_DIR=${{ env.VCPKG_INSTALLED_DIR }}
+            LD_LIBRARY_PATH=${{ env.VCPKG_INSTALLED_DIR }}/${{ matrix.triplet }}/lib
+        run: echo "CIBW_ENVIRONMENT_COMMON=$COMMON_ENV" >> $GITHUB_ENV
 
-  #     - name: Run cibuildwheel
-  #       env:
-  #         CIBW_BUILD: ${{ matrix.cpython }}-${{ matrix.extra_build }}
-  #         CIBW_BUILD_FRONTEND: build
-  #         CIBW_ARCHS: ${{ matrix.arch }}
-  #         CIBW_BEFORE_ALL_LINUX: yum install -y zip flex bison gcc-gfortran
-  #         CIBW_BEFORE_ALL_MACOS: |
-  #           brew install python llvm
-  #           brew reinstall gcc
-  #         CIBW_BEFORE_BUILD_MACOS: |
-  #           export PATH="/opt/homebrew/opt/llvm/bin:$PATH"
-  #           export LDFLAGS="-L/opt/homebrew/opt/llvm/lib"
-  #           export CPPFLAGS="-I/opt/homebrew/opt/llvm/include"
-  #         CIBW_ENVIRONMENT: ${{ env.CIBW_ENVIRONMENT_COMMON }}
-  #         CIBW_ENVIRONMENT_MACOS: >
-  #           ${{ env.CIBW_ENVIRONMENT_COMMON }}
-  #           MACOSX_DEPLOYMENT_TARGET=${{ matrix.deployment_target }}
-  #         CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/manylinux_2_28_x86_64
-  #         CIBW_MANYLINUX_AARCH64_IMAGE: quay.io/pypa/manylinux_2_28_aarch64
-  #         CIBW_TEST_EXTRAS_LINUX: applications,test
-  #         CIBW_TEST_COMMAND: bash {package}/ci/scripts/run_tests.sh
-  #         CIBW_REPAIR_WHEEL_COMMAND_LINUX: >
-  #           auditwheel repair
-  #           -w {dest_dir} {wheel}
-  #           --exclude libarrow_python.so.2100
-  #           --exclude libarrow.so.2100
-  #         CIBW_REPAIR_WHEEL_COMMAND_MACOS: |
-  #           DYLD_LIBRARY_PATH=$LD_LIBRARY_PATH delocate-listdeps {wheel}
-  #           DYLD_LIBRARY_PATH=$LD_LIBRARY_PATH delocate-wheel \
-  #             --require-archs {delocate_archs} \
-  #             -w {dest_dir} \
-  #             -v {wheel} \
-  #             --exclude libarrow_python.2100.dylib \
-  #             --exclude libarrow.2100.dylib \
-  #             --ignore-missing-dependencies
-  #       uses: pypa/cibuildwheel@v3.1.4
+      - name: Run cibuildwheel
+        env:
+          CIBW_BUILD: ${{ matrix.cpython }}-${{ matrix.extra_build }}
+          CIBW_BUILD_FRONTEND: build
+          CIBW_ARCHS: ${{ matrix.arch }}
+          CIBW_BEFORE_ALL_LINUX: yum install -y zip flex bison gcc-gfortran
+          CIBW_BEFORE_ALL_MACOS: |
+            brew install python llvm
+            brew reinstall gcc
+          CIBW_BEFORE_BUILD_MACOS: |
+            export PATH="/opt/homebrew/opt/llvm/bin:$PATH"
+            export LDFLAGS="-L/opt/homebrew/opt/llvm/lib"
+            export CPPFLAGS="-I/opt/homebrew/opt/llvm/include"
+          CIBW_ENVIRONMENT: ${{ env.CIBW_ENVIRONMENT_COMMON }}
+          CIBW_ENVIRONMENT_MACOS: >
+            ${{ env.CIBW_ENVIRONMENT_COMMON }}
+            MACOSX_DEPLOYMENT_TARGET=${{ matrix.deployment_target }}
+          CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/manylinux_2_28_x86_64
+          CIBW_MANYLINUX_AARCH64_IMAGE: quay.io/pypa/manylinux_2_28_aarch64
+          CIBW_TEST_EXTRAS_LINUX: applications,test
+          CIBW_TEST_COMMAND: bash {package}/ci/scripts/run_tests.sh
+          CIBW_REPAIR_WHEEL_COMMAND_LINUX: >
+            auditwheel repair
+            -w {dest_dir} {wheel}
+            --exclude libarrow_python.so.2100
+            --exclude libarrow.so.2100
+          CIBW_REPAIR_WHEEL_COMMAND_MACOS: |
+            DYLD_LIBRARY_PATH=$LD_LIBRARY_PATH delocate-listdeps {wheel}
+            DYLD_LIBRARY_PATH=$LD_LIBRARY_PATH delocate-wheel \
+              --require-archs {delocate_archs} \
+              -w {dest_dir} \
+              -v {wheel} \
+              --exclude libarrow_python.2100.dylib \
+              --exclude libarrow.2100.dylib \
+              --ignore-missing-dependencies
+        uses: pypa/cibuildwheel@v3.1.4
 
-  #     - name: Upload wheel artifacts
-  #       uses: actions/upload-artifact@v4
-  #       with:
-  #         name: ${{ env.ARTIFACT_NAME }}-${{ matrix.os_short }}-${{ matrix.cpython }}-${{ matrix.arch }}
-  #         path: ./wheelhouse/*.whl
+      - name: Upload wheel artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.ARTIFACT_NAME }}-${{ matrix.os_short }}-${{ matrix.cpython }}-${{ matrix.arch }}
+          path: ./wheelhouse/*.whl
 
-  #     # - name: Debug with tmate on failure
-  #     #   if: ${{ failure() }}
-  #     #   uses: mxschmitt/action-tmate@v3
+      # - name: Debug with tmate on failure
+      #   if: ${{ failure() }}
+      #   uses: mxschmitt/action-tmate@v3
 
-  # upload-to-test-pypi:
-  #   name: Upload release to Test PyPI
-  #   needs: [build-sdist, build-wheels]
-  #   runs-on: ubuntu-latest
-  #   environment:
-  #     name: release-test
-  #   permissions:
-  #     id-token: write
-  #   steps:
-  #     - name: Download distribution artifacts
-  #       uses: actions/download-artifact@v5
-  #       with:
-  #         pattern: ${{ env.ARTIFACT_NAME }}-*
-  #         merge-multiple: true
-  #         path: dist
+  upload-to-test-pypi:
+    name: Upload release to Test PyPI
+    needs: [build-sdist, build-wheels]
+    runs-on: ubuntu-latest
+    environment:
+      name: release-test
+    permissions:
+      id-token: write
+    steps:
+      - name: Download distribution artifacts
+        uses: actions/download-artifact@v5
+        with:
+          pattern: ${{ env.ARTIFACT_NAME }}-*
+          merge-multiple: true
+          path: dist
 
-  #     - name: List artifacts
-  #       run: ls -lh dist
+      - name: List artifacts
+        run: ls -lh dist
 
-  #     - name: Publish package distributions to Test PyPI
-  #       uses: pypa/gh-action-pypi-publish@release/v1
-  #       with:
-  #         repository-url: https://test.pypi.org/legacy/
-  #         skip-existing: true
-  #       continue-on-error: true
+      - name: Publish package distributions to Test PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          skip-existing: true
+        continue-on-error: true
 
-  # upload-to-pypi:
-  #   name: Upload release to PyPI
-  #   if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
-  #   needs: [build-sdist, build-wheels]
-  #   runs-on: ubuntu-latest
-  #   environment:
-  #     name: release
-  #   permissions:
-  #     id-token: write
-  #   steps:
-  #     - name: Download distribution artifacts
-  #       uses: actions/download-artifact@v5
-  #       with:
-  #         pattern: ${{ env.ARTIFACT_NAME }}-*
-  #         merge-multiple: true
-  #         path: dist
+  upload-to-pypi:
+    name: Upload release to PyPI
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+    needs: [build-sdist, build-wheels]
+    runs-on: ubuntu-latest
+    environment:
+      name: release
+    permissions:
+      id-token: write
+    steps:
+      - name: Download distribution artifacts
+        uses: actions/download-artifact@v5
+        with:
+          pattern: ${{ env.ARTIFACT_NAME }}-*
+          merge-multiple: true
+          path: dist
 
-  #     - name: List artifacts
-  #       run: ls -lh dist
+      - name: List artifacts
+        run: ls -lh dist
 
-  #     - name: Publish package distributions to PyPI
-  #       uses: pypa/gh-action-pypi-publish@release/v1
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,12 +74,14 @@ jobs:
           cmake -S . -B build
           cmake --build build
 
-      - name: Fail
-        run: exit 1
+      - name: Execute C++ tests
+        run: |
+          cd build
+          ctest --verbose
 
-      - name: Debug with tmate on failure
-        if: ${{ failure() }}
-        uses: mxschmitt/action-tmate@v3
+      # - name: Debug with tmate on failure
+      #   if: ${{ failure() }}
+      #   uses: mxschmitt/action-tmate@v3
 
 
   build-wheels:

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,12 @@
 History
 =======
 
+X.Y.Z (DD-MM-YYYY)
+------------------
+* Add a ``table.row_shapes`` method that returns column row shapes
+  as an Arrow Array (:pr:`169`)
+* Impute missing rows from result shape (:pr:`169`)
+
 0.3.0 (21-06-2025)
 ------------------
 * Upgrade to pyarrow 21 (:pr:`160`)

--- a/cpp/arcae/new_table_proxy.h
+++ b/cpp/arcae/new_table_proxy.h
@@ -70,6 +70,10 @@ class NewTableProxy {
                                 const std::shared_ptr<arrow::Array>& data,
                                 const detail::Selection& selection = {}) const;
 
+  // Get the row shapes for the given column and row selection
+  arrow::Result<std::shared_ptr<arrow::Array>> GetRowShapes(
+      const std::string& column, const detail::Selection& selection = {}) const;
+
   // Return the URL of this table
   arrow::Result<std::string> Name() const;
 
@@ -88,7 +92,6 @@ class NewTableProxy {
   // Add a column to the table
   arrow::Result<bool> AddColumns(const std::string& json_columndescs,
                                  const std::string& json_dminfo = {});
-
   // Get a pointer to the IsolatedTableProxy
   std::shared_ptr<detail::IsolatedTableProxy> Proxy() const { return itp_; }
 

--- a/cpp/arcae/result_shape.cc
+++ b/cpp/arcae/result_shape.cc
@@ -119,7 +119,7 @@ Result<RowShapes> MakeRowData(const TableColumn& column, const Selection& select
     // otherwise, the entire column
   } else {
     shapes.reserve(column.nrow());
-    for (std::size_t r = 0; r < column.nrow(); ++r) {
+    for (casacore::rownr_t r = 0; r < column.nrow(); ++r) {
       ARROW_ASSIGN_OR_RAISE(auto shape, GetClippedColumnShape(r));
       shapes.emplace_back(std::move(shape));
     }
@@ -477,7 +477,10 @@ Result<std::vector<std::shared_ptr<arrow::Int32Array>>> ResultShapeData::GetOffs
 
   // Build the offset arrays
   if (!IsFixed()) {
-    ARROW_RETURN_NOT_OK(BuildFn([&](auto r, auto d) { return GetRowShape(r)[d]; }));
+    ARROW_RETURN_NOT_OK(BuildFn([&](auto r, auto d) {
+      const auto& row_shape = GetRowShape(r);
+      return row_shape.size() == 0 ? 0 : row_shape[d];
+    }));
   } else {
     ARROW_RETURN_NOT_OK(BuildFn([&](auto r, auto d) { return (*shape_)[d]; }));
   }

--- a/cpp/arcae/result_shape.cc
+++ b/cpp/arcae/result_shape.cc
@@ -417,7 +417,7 @@ Result<std::shared_ptr<arrow::Array>> ResultShapeData::GetShapeArray() const noe
   if (IsFixed()) {
     auto shape = GetShape();
     for (std::size_t row = 0; row < nrow; ++row) {
-      for (std::size_t dim = 0; dim < ndim; ++dim) {
+      for (int dim = ndim - 1; dim >= 0; --dim) {
         ARROW_RETURN_NOT_OK(shape_data_builder.Append(shape[dim]));
       }
     }
@@ -430,7 +430,7 @@ Result<std::shared_ptr<arrow::Array>> ResultShapeData::GetShapeArray() const noe
       auto shape = GetRowShape(row);
       ARROW_RETURN_NOT_OK(null_nitmap_builder.Append(shape.size() != 0));
       if (shape.size() == 0) shape = IPosition(ndim, 0);
-      for (std::size_t dim = 0; dim < ndim; ++dim) {
+      for (int dim = ndim - 1; dim >= 0; --dim) {
         ARROW_RETURN_NOT_OK(shape_data_builder.Append(shape[dim]));
       }
     }

--- a/cpp/arcae/result_shape.h
+++ b/cpp/arcae/result_shape.h
@@ -16,6 +16,7 @@
 #include <casacore/tables/Tables/TableColumn.h>
 
 #include "arcae/selection.h"
+#include "arrow/array/array_base.h"
 
 namespace arcae {
 namespace detail {
@@ -93,6 +94,9 @@ struct ResultShapeData {
   // Get the number of elements in the result
   std::size_t nElements() const noexcept;
 
+  // Get an Arrow Array describing the row shapes
+  arrow::Result<std::shared_ptr<arrow::Array>> GetShapeArray() const noexcept;
+
   // Get ListArray offsets
   arrow::Result<std::vector<std::shared_ptr<arrow::Int32Array>>> GetOffsets()
       const noexcept;
@@ -100,7 +104,8 @@ struct ResultShapeData {
   // Create a ResultShapeData instance suitable for reading
   static arrow::Result<ResultShapeData> MakeRead(
       const casacore::TableColumn& column, const Selection& selection = Selection(),
-      const std::shared_ptr<arrow::Array>& result = nullptr);
+      const std::shared_ptr<arrow::Array>& result = nullptr,
+      bool allow_missing_rows = false);
 
   // Create a ResultShapeData instance suitable for writing
   static arrow::Result<ResultShapeData> MakeWrite(

--- a/src/arcae/lib/arrow_tables.pxd
+++ b/src/arcae/lib/arrow_tables.pxd
@@ -70,6 +70,9 @@ cdef extern from "arcae/new_table_proxy.h" namespace "arcae" nogil:
             const string & column,
             const shared_ptr[CArray] & data,
             const CSelection & selection)
+        CResult[shared_ptr[CArray]] GetRowShapes " NewTableProxy::GetRowShapes"(
+            const string & column,
+            const CSelection & selection)
         CResult[string] Name " NewTableProxy::Name"()
         CResult[string] GetTableDescriptor " NewTableProxy::GetTableDescriptor"()
         CResult[string] GetColumnDescriptor "NewTableProxy::GetColumnDescriptor"(

--- a/src/arcae/lib/arrow_tables.pyx
+++ b/src/arcae/lib/arrow_tables.pyx
@@ -261,6 +261,24 @@ cdef class Table:
         with nogil:
             GetResultValue(self.c_table.get().PutColumn(cpp_column, carray, selection))
 
+    def row_shapes(
+        self,
+        column: str,
+        index: FullIndex | None = None
+     ) -> pa.Array:
+        """ Returns the row shapes for the given column and index.
+        Missing rows are nulled"""
+        cdef:
+            string cpp_column = tobytes(column)
+            CSelection selection = build_selection(index)
+
+        with nogil:
+            carray = GetResultValue(
+                self.c_table.get().GetRowShapes(cpp_column, selection)
+            )
+
+        return pyarrow_wrap_array(carray)
+
     def _numpy_to_arrow(self, data: np.ndarray) -> pa.array:
         """ Covert numpy array into a nested FixedSizeListArrays """
         shape = data.shape

--- a/src/arcae/tests/test_pytable.py
+++ b/src/arcae/tests/test_pytable.py
@@ -168,6 +168,21 @@ def test_column_cases(column_case_table):
     assert "UNCONSTRAINED" not in T.column_names
 
 
+def test_row_shapes(column_case_table):
+    table = arcae.table(column_case_table)
+
+    assert isinstance(table.row_shapes("SCALAR"), pa.NullArray)
+    assert table.row_shapes("SCALAR").to_pylist() == [None, None, None]
+
+    assert table.row_shapes("VARIABLE").to_pylist() == [[2, 1, 3], [2, 2, 3], [2, 3, 3]]
+    assert table.row_shapes("VARIABLE", ([1, 2],)).to_pylist() == [[2, 2, 3], [2, 3, 3]]
+    assert table.row_shapes("VARIABLE", ([0],)).to_pylist() == [[2, 1, 3]]
+
+    assert table.row_shapes("FIXED").to_pylist() == [[4, 2], [4, 2], [4, 2]]
+    assert table.row_shapes("FIXED", ([1, 2],)).to_pylist() == [[4, 2], [4, 2]]
+    assert table.row_shapes("FIXED", ([0],)).to_pylist() == [[4, 2]]
+
+
 def test_complex_cases(complex_case_table):
     from arcae import config
 

--- a/src/arcae/tests/test_pytable.py
+++ b/src/arcae/tests/test_pytable.py
@@ -174,13 +174,13 @@ def test_row_shapes(column_case_table):
     assert isinstance(table.row_shapes("SCALAR"), pa.NullArray)
     assert table.row_shapes("SCALAR").to_pylist() == [None, None, None]
 
-    assert table.row_shapes("VARIABLE").to_pylist() == [[2, 1, 3], [2, 2, 3], [2, 3, 3]]
-    assert table.row_shapes("VARIABLE", ([1, 2],)).to_pylist() == [[2, 2, 3], [2, 3, 3]]
-    assert table.row_shapes("VARIABLE", ([0],)).to_pylist() == [[2, 1, 3]]
+    assert table.row_shapes("VARIABLE").to_pylist() == [[3, 1, 2], [3, 2, 2], [3, 3, 2]]
+    assert table.row_shapes("VARIABLE", ([1, 2],)).to_pylist() == [[3, 2, 2], [3, 3, 2]]
+    assert table.row_shapes("VARIABLE", ([0],)).to_pylist() == [[3, 1, 2]]
 
-    assert table.row_shapes("FIXED").to_pylist() == [[4, 2], [4, 2], [4, 2]]
-    assert table.row_shapes("FIXED", ([1, 2],)).to_pylist() == [[4, 2], [4, 2]]
-    assert table.row_shapes("FIXED", ([0],)).to_pylist() == [[4, 2]]
+    assert table.row_shapes("FIXED").to_pylist() == [[2, 4], [2, 4], [2, 4]]
+    assert table.row_shapes("FIXED", ([1, 2],)).to_pylist() == [[2, 4], [2, 4]]
+    assert table.row_shapes("FIXED", ([0],)).to_pylist() == [[2, 4]]
 
 
 def test_complex_cases(complex_case_table):


### PR DESCRIPTION
* Support reasoning about missing rows in ResultShapeData.
* Impute missing row shapes if a result shape is provided to getcol.
* Add a ``table.row_shapes`` method that returns column row shapes  as an Arrow Array.