### PR TITLE
Support missing rows when a result array is supplied to Table.getcol

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 0.3.2 (DD-MM-2025)
 ------------------
+* Pass allow_missing_rows depending on presence of result data (:pr:`174`)
 * Disable overly aggressive casacore logging of non-standard data types (:pr:`173`)
 
 0.3.1 (10-09-2025)

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,7 +4,11 @@ History
 
 0.3.2 (DD-MM-2025)
 ------------------
-* Pass allow_missing_rows depending on presence of result data (:pr:`174`)
+* Support missing column rows when result arrays are supplied during reads (:pr:`174`)
+* Correct setting the shapes of missing column row rows during writes of
+  variably shaped data (:pr:`174`)
+* Fixes a data partitioning bug where the shape for a particular row was
+  associated with a raw index into the result shape, instead of a memory index (:pr:`174`)
 * Default arrow allocation alignment if type size is not a power of 2 (:pr:`176`)
 * Disable overly aggressive casacore logging of non-standard data types (:pr:`173`)
 

--- a/cpp/arcae/data_partition.h
+++ b/cpp/arcae/data_partition.h
@@ -196,11 +196,19 @@ struct DataChunk {
 
   // Does the chunk refer to negative disk indices
   bool IsEmpty() const noexcept;
+
+  // Print some debugging information about this chunk
+  std::string ToString() const;
 };
 
-// A partition of the data into a series
-// of chunks that can be independently processed
+// A DataPartition is a mapping between indices on disk
+// and indices in memory. The partition is split into
+// multiple chunks, where each chunk represents a contiguous
+// read of data from disk.
 struct DataPartition {
+  // Construct a DataPartition from a selection object describing indices of
+  // data within a column on disk and a result_shape object describing the
+  // layout of the source/destination of data within memory.
   static arrow::Result<DataPartition> Make(const Selection& selection,
                                            const ResultShapeData& result_shape);
 

--- a/cpp/arcae/isolated_table_proxy.cc
+++ b/cpp/arcae/isolated_table_proxy.cc
@@ -5,10 +5,10 @@
 #include <limits>
 #include <memory>
 
+#include <arrow/status.h>
+#include <arrow/util/future.h>
 #include <arrow/util/logging.h>
-#include "arrow/status.h"
-#include "arrow/util/future.h"
-#include "arrow/util/thread_pool.h"
+#include <arrow/util/thread_pool.h>
 
 #include <casacore/tables/Tables/TableProxy.h>
 

--- a/cpp/arcae/isolated_table_proxy.cc
+++ b/cpp/arcae/isolated_table_proxy.cc
@@ -7,7 +7,6 @@
 
 #include <arrow/util/logging.h>
 #include "arrow/status.h"
-#include "arrow/util/functional.h"
 #include "arrow/util/future.h"
 #include "arrow/util/thread_pool.h"
 

--- a/cpp/arcae/new_table_proxy.cc
+++ b/cpp/arcae/new_table_proxy.cc
@@ -29,7 +29,6 @@ using ::arrow::Table;
 using ::casacore::JsonOut;
 using ::casacore::JsonParser;
 using ::casacore::Record;
-using ::casacore::TableColumn;
 using ::casacore::TableProxy;
 
 namespace arcae {
@@ -105,9 +104,8 @@ Result<std::shared_ptr<Array>> NewTableProxy::GetRowShapes(
                      const TableProxy& tp) -> Result<std::shared_ptr<Array>> {
         ARROW_RETURN_NOT_OK(detail::ColumnExists(tp.table(), column));
         auto table_column = casacore::TableColumn(tp.table(), column);
-        ARROW_ASSIGN_OR_RAISE(
-            auto shape_data,
-            ResultShapeData::MakeRead(table_column, selection, nullptr, true));
+        ARROW_ASSIGN_OR_RAISE(auto shape_data,
+                              ResultShapeData::MakeRead(table_column, selection, true));
         return shape_data.GetShapeArray();
       })
       .MoveResult();

--- a/cpp/arcae/read_impl.cc
+++ b/cpp/arcae/read_impl.cc
@@ -385,6 +385,9 @@ Future<std::shared_ptr<Array>> ReadImpl(const std::shared_ptr<IsolatedTableProxy
         ARROW_RETURN_NOT_OK(ColumnExists(tp.table(), column));
         auto table_column = TableColumn(tp.table(), column);
 
+        // If a result array is supplied we can derive ResultShapeData from it
+        // Also iterate over the selected rows and negate any missing rows as
+        // this elides reads in these cases
         if (result) {
           ARROW_ASSIGN_OR_RAISE(auto shape_data,
                                 ResultShapeData::FromArray(table_column, result));
@@ -395,6 +398,8 @@ Future<std::shared_ptr<Array>> ReadImpl(const std::shared_ptr<IsolatedTableProxy
                              std::make_shared<Selection>(std::move(modified_selection))};
         }
 
+        // Otherwise we the ResultShapeData must be derived wholly from
+        // the contents of the column
         ARROW_ASSIGN_OR_RAISE(auto shape_data,
                               ResultShapeData::MakeRead(table_column, selection));
         return ShapeResult{std::make_shared<ResultShapeData>(std::move(shape_data)),

--- a/cpp/arcae/read_impl.cc
+++ b/cpp/arcae/read_impl.cc
@@ -398,7 +398,7 @@ Future<std::shared_ptr<Array>> ReadImpl(const std::shared_ptr<IsolatedTableProxy
                              std::make_shared<Selection>(std::move(modified_selection))};
         }
 
-        // Otherwise we the ResultShapeData must be derived wholly from
+        // Otherwise the ResultShapeData must be derived wholly from
         // the contents of the column
         ARROW_ASSIGN_OR_RAISE(auto shape_data,
                               ResultShapeData::MakeRead(table_column, selection));

--- a/cpp/arcae/read_impl.cc
+++ b/cpp/arcae/read_impl.cc
@@ -384,8 +384,10 @@ Future<std::shared_ptr<Array>> ReadImpl(const std::shared_ptr<IsolatedTableProxy
                         const TableProxy& tp) mutable -> Result<ShapeResult> {
         ARROW_RETURN_NOT_OK(ColumnExists(tp.table(), column));
         auto table_column = TableColumn(tp.table(), column);
+        bool allow_missing_rows = !bool(result);
         ARROW_ASSIGN_OR_RAISE(auto shape_data,
-                              ResultShapeData::MakeRead(table_column, selection, result));
+                              ResultShapeData::MakeRead(table_column, selection, result,
+                                                        allow_missing_rows));
         return ShapeResult{std::make_shared<ResultShapeData>(std::move(shape_data)),
                            std::make_shared<Selection>(std::move(selection))};
       });

--- a/cpp/arcae/read_impl.cc
+++ b/cpp/arcae/read_impl.cc
@@ -350,14 +350,14 @@ Result<std::shared_ptr<Array>> MakeArray(const ResultShapeData& result_shape,
   // Introduce shape nesting
   if (result_shape.IsFixed() && strat == ConvertStrategy::FIXED) {
     // Exclude the row dimension
-    auto ndim = result_shape.nDim();
+    ARROW_ASSIGN_OR_RAISE(auto ndim, result_shape.ConsistentNDim());
     auto shape = result_shape.GetShape().getFirst(ndim - 1);
     for (auto dim : shape) {
       ARROW_ASSIGN_OR_RAISE(result, FixedSizeListArray::FromArrays(result, dim));
     }
   } else {
     ARROW_ASSIGN_OR_RAISE(auto offsets, result_shape.GetOffsets());
-    assert(offsets.size() == result_shape.nDim() - 1);
+    assert(int(offsets.size()) == result_shape.nDim() - 1);
     for (const auto& offset : offsets) {
       ARROW_ASSIGN_OR_RAISE(result, ListArray::FromArrays(*offset, *result));
     }
@@ -384,9 +384,19 @@ Future<std::shared_ptr<Array>> ReadImpl(const std::shared_ptr<IsolatedTableProxy
                         const TableProxy& tp) mutable -> Result<ShapeResult> {
         ARROW_RETURN_NOT_OK(ColumnExists(tp.table(), column));
         auto table_column = TableColumn(tp.table(), column);
-        ARROW_ASSIGN_OR_RAISE(
-            auto shape_data,
-            ResultShapeData::MakeRead(table_column, selection, result, bool(result)));
+
+        if (result) {
+          ARROW_ASSIGN_OR_RAISE(auto shape_data,
+                                ResultShapeData::FromArray(table_column, result));
+          ARROW_ASSIGN_OR_RAISE(
+              auto modified_selection,
+              shape_data.NegateMissingSelectedRows(table_column, selection));
+          return ShapeResult{std::make_shared<ResultShapeData>(std::move(shape_data)),
+                             std::make_shared<Selection>(std::move(modified_selection))};
+        }
+
+        ARROW_ASSIGN_OR_RAISE(auto shape_data,
+                              ResultShapeData::MakeRead(table_column, selection));
         return ShapeResult{std::make_shared<ResultShapeData>(std::move(shape_data)),
                            std::make_shared<Selection>(std::move(selection))};
       });

--- a/cpp/arcae/read_impl.cc
+++ b/cpp/arcae/read_impl.cc
@@ -384,10 +384,9 @@ Future<std::shared_ptr<Array>> ReadImpl(const std::shared_ptr<IsolatedTableProxy
                         const TableProxy& tp) mutable -> Result<ShapeResult> {
         ARROW_RETURN_NOT_OK(ColumnExists(tp.table(), column));
         auto table_column = TableColumn(tp.table(), column);
-        bool allow_missing_rows = !bool(result);
-        ARROW_ASSIGN_OR_RAISE(auto shape_data,
-                              ResultShapeData::MakeRead(table_column, selection, result,
-                                                        allow_missing_rows));
+        ARROW_ASSIGN_OR_RAISE(
+            auto shape_data,
+            ResultShapeData::MakeRead(table_column, selection, result, bool(result)));
         return ShapeResult{std::make_shared<ResultShapeData>(std::move(shape_data)),
                            std::make_shared<Selection>(std::move(selection))};
       });

--- a/cpp/arcae/result_shape.cc
+++ b/cpp/arcae/result_shape.cc
@@ -352,7 +352,7 @@ std::size_t ResultShapeData::MaxDimensionSize() const noexcept {
 Result<std::size_t> ResultShapeData::FlatOffset(
     const absl::Span<const IndexType>& index) const noexcept {
   ARROW_ASSIGN_OR_RAISE(auto ndim, ConsistentNDim());
-  assert(index.size() == ndim);
+  assert(index.size() == std::size_t(ndim));
   std::size_t offset = 0;
 
   // Fixed case

--- a/cpp/arcae/result_shape.h
+++ b/cpp/arcae/result_shape.h
@@ -17,6 +17,7 @@
 
 #include "arcae/selection.h"
 #include "arrow/array/array_base.h"
+#include "arrow/status.h"
 
 namespace arcae {
 namespace detail {
@@ -46,15 +47,24 @@ using RowShapes = std::vector<casacore::IPosition>;
 struct ResultShapeData {
   std::string column_name_;
   std::optional<casacore::IPosition> shape_;
-  std::size_t ndim_;
+  int ndim_;
   casacore::DataType dtype_;
   std::optional<RowShapes> row_shapes_;
 
   // Return the Column Name
   const std::string& GetName() const noexcept { return column_name_; }
 
+  // Return number of dimensions, if they are >= 0
+  // else an error status
+  arrow::Result<int> ConsistentNDim() const {
+    if (ndim_ >= 0) return ndim_;
+    return arrow::Status::Invalid("Result shape dimensions are not consistent");
+  }
+
   // Return the Number of Dimensions in the Column
-  std::size_t nDim() const noexcept { return ndim_; }
+  // Prefer ConsistentNDim for code where row shapes
+  // are assumed to have the same rank
+  int nDim() const noexcept { return ndim_; }
 
   // Number of Rows in the Shape
   std::size_t nRows() const noexcept {
@@ -67,7 +77,8 @@ struct ResultShapeData {
   std::size_t MaxDimensionSize() const noexcept;
 
   // Obtain the flat offset at the specified
-  std::size_t FlatOffset(const absl::Span<const IndexType>& index) const noexcept;
+  arrow::Result<std::size_t> FlatOffset(
+      const absl::Span<const IndexType>& index) const noexcept;
 
   // Is the result shape fixed?
   bool IsFixed() const noexcept { return shape_.has_value(); }
@@ -101,11 +112,19 @@ struct ResultShapeData {
   arrow::Result<std::vector<std::shared_ptr<arrow::Int32Array>>> GetOffsets()
       const noexcept;
 
+  // For any degenerate shapes representing missing rows in the ResultShapeData object
+  // convert the associated row in the selection to -1
+  arrow::Result<Selection> NegateMissingSelectedRows(const casacore::TableColumn& column,
+                                                     const Selection& selection);
+
   // Create a ResultShapeData instance suitable for reading
-  static arrow::Result<ResultShapeData> MakeRead(
-      const casacore::TableColumn& column, const Selection& selection = Selection(),
-      const std::shared_ptr<arrow::Array>& result = nullptr,
-      bool allow_missing_rows = false);
+  static arrow::Result<ResultShapeData> MakeRead(const casacore::TableColumn& column,
+                                                 const Selection& selection = Selection(),
+                                                 bool allow_missing_rows = false);
+
+  // Create a ResultShapeData instance from an array
+  static arrow::Result<ResultShapeData> FromArray(
+      const casacore::TableColumn& column, const std::shared_ptr<arrow::Array>& data);
 
   // Create a ResultShapeData instance suitable for writing
   static arrow::Result<ResultShapeData> MakeWrite(

--- a/cpp/tests/result_shape_test.cc
+++ b/cpp/tests/result_shape_test.cc
@@ -1,4 +1,5 @@
 #include <arrow/json/from_string.h>
+#include <arrow/testing/builder.h>
 #include <arrow/testing/gtest_util.h>
 #include <arrow/type_fwd.h>
 
@@ -36,11 +37,9 @@ using casacore::Complex;
 using casacore::DataType;
 using MS = casacore::MeasurementSet;
 using MSColumns = casacore::MSMainEnums::PredefinedColumns;
-using casacore::Record;
 using casacore::SetupNewTable;
 using casacore::Table;
 using casacore::TableDesc;
-using casacore::TableLock;
 using casacore::TableProxy;
 using casacore::TiledColumnStMan;
 using IPos = casacore::IPosition;
@@ -53,7 +52,7 @@ static constexpr std::size_t kncorr = 2;
 
 namespace {
 
-class ColumnShapeTest : public ::testing::Test {
+class ResultShapeTest : public ::testing::Test {
  protected:
   TableProxy table_proxy_;
   std::string table_name_;
@@ -136,7 +135,7 @@ class ColumnShapeTest : public ::testing::Test {
   }
 };
 
-TEST_F(ColumnShapeTest, ReadFixed) {
+TEST_F(ResultShapeTest, ReadFixed) {
   auto fixed = GetArrayColumn<Complex>(table_proxy_.table(), "MODEL_DATA");
   ASSERT_OK_AND_ASSIGN(auto shape_data, ResultShapeData::MakeRead(fixed));
 
@@ -150,7 +149,7 @@ TEST_F(ColumnShapeTest, ReadFixed) {
   ASSERT_OK_AND_ASSIGN(auto offsets, shape_data.GetOffsets());
 }
 
-TEST_F(ColumnShapeTest, ReadFixedSelection) {
+TEST_F(ResultShapeTest, ReadFixedSelection) {
   auto fixed = GetArrayColumn<Complex>(table_proxy_.table(), "MODEL_DATA");
   auto sel = SelectionBuilder::FromInit({{0, 1}});
   ASSERT_OK_AND_ASSIGN(auto shape_data, ResultShapeData::MakeRead(fixed, sel));
@@ -177,7 +176,7 @@ TEST_F(ColumnShapeTest, ReadFixedSelection) {
   ASSERT_OK_AND_ASSIGN(offsets, shape_data.GetOffsets());
 }
 
-TEST_F(ColumnShapeTest, ReadVariable) {
+TEST_F(ResultShapeTest, ReadVariable) {
   auto var = GetArrayColumn<Complex>(table_proxy_.table(), "VAR_DATA");
   ASSERT_OK_AND_ASSIGN(auto shape_data, ResultShapeData::MakeRead(var));
 
@@ -192,7 +191,7 @@ TEST_F(ColumnShapeTest, ReadVariable) {
   ASSERT_OK_AND_ASSIGN(auto offsets, shape_data.GetOffsets());
 }
 
-TEST_F(ColumnShapeTest, ReadSparseVariable) {
+TEST_F(ResultShapeTest, ReadSparseVariable) {
   auto var = GetArrayColumn<Complex>(table_proxy_.table(), "VAR_SPARSE");
   ASSERT_OK_AND_ASSIGN(auto shape_data,
                        ResultShapeData::MakeRead(var, Selection(), true));
@@ -210,7 +209,32 @@ TEST_F(ColumnShapeTest, ReadSparseVariable) {
   ASSERT_OK_AND_ASSIGN(auto offsets, shape_data.GetOffsets());
 }
 
-TEST_F(ColumnShapeTest, ReadVariableSelection) {
+TEST_F(ResultShapeTest, NegateSparseVariable) {
+  auto var = GetArrayColumn<Complex>(table_proxy_.table(), "VAR_SPARSE");
+
+  // Create a result array filled with a default value
+  std::shared_ptr<arrow::Array> result;
+  std::vector<float> values(knrow * knchan * kncorr * 2, 0.0);
+  arrow::ArrayFromVector<arrow::FloatType>(arrow::float32(), values, &result);
+  ASSERT_OK_AND_ASSIGN(result, arrow::FixedSizeListArray::FromArrays(result, 2));
+  ASSERT_OK_AND_ASSIGN(result, arrow::FixedSizeListArray::FromArrays(result, kncorr));
+  ASSERT_OK_AND_ASSIGN(result, arrow::FixedSizeListArray::FromArrays(result, knchan));
+  EXPECT_EQ(result->length(), knrow);
+
+  ASSERT_OK_AND_ASSIGN(auto shape_data, ResultShapeData::FromArray(var, result));
+  ASSERT_OK_AND_ASSIGN(auto selection,
+                       shape_data.NegateMissingSelectedRows(var, Selection()));
+  EXPECT_TRUE(selection.HasRowSpan());
+  auto span = selection.GetRowSpan();
+  for (std::size_t r = 0; r < span.size(); ++r) {
+    if (r == 1 || r == 7)
+      EXPECT_EQ(span[r], -1);
+    else
+      EXPECT_EQ(span[r], r);
+  }
+}
+
+TEST_F(ResultShapeTest, ReadVariableSelection) {
   auto var = GetArrayColumn<Complex>(table_proxy_.table(), "VAR_DATA");
   auto sel = SelectionBuilder::FromInit({{0, 1}});
   ASSERT_OK_AND_ASSIGN(auto shape_data, ResultShapeData::MakeRead(var, sel));
@@ -250,7 +274,7 @@ TEST_F(ColumnShapeTest, ReadVariableSelection) {
   ASSERT_OK_AND_ASSIGN(offsets, shape_data.GetOffsets());
 }
 
-TEST_F(ColumnShapeTest, WriteFixed) {
+TEST_F(ResultShapeTest, WriteFixed) {
   auto fixed = GetArrayColumn<Complex>(table_proxy_.table(), "MODEL_DATA");
   auto dtype = arrow::fixed_size_list(
       arrow::fixed_size_list(arrow::fixed_size_list(arrow::float32(), 2), 2), 2);
@@ -271,7 +295,7 @@ TEST_F(ColumnShapeTest, WriteFixed) {
   ASSERT_OK_AND_ASSIGN(auto offsets, shape_data.GetOffsets());
 }
 
-TEST_F(ColumnShapeTest, WriteVariable) {
+TEST_F(ResultShapeTest, WriteVariable) {
   auto var = GetArrayColumn<Complex>(table_proxy_.table(), "VAR_DATA");
   auto dtype = arrow::list(arrow::list(arrow::list(arrow::float32())));
 

--- a/cpp/tests/result_shape_test.cc
+++ b/cpp/tests/result_shape_test.cc
@@ -195,7 +195,7 @@ TEST_F(ColumnShapeTest, ReadVariable) {
 TEST_F(ColumnShapeTest, ReadSparseVariable) {
   auto var = GetArrayColumn<Complex>(table_proxy_.table(), "VAR_SPARSE");
   ASSERT_OK_AND_ASSIGN(auto shape_data,
-                       ResultShapeData::MakeRead(var, Selection(), nullptr, true));
+                       ResultShapeData::MakeRead(var, Selection(), true));
 
   EXPECT_EQ(shape_data.GetName(), "VAR_SPARSE");
   EXPECT_FALSE(shape_data.IsFixed());

--- a/cpp/tests/selection_test.cc
+++ b/cpp/tests/selection_test.cc
@@ -81,3 +81,26 @@ TEST(SelectionTests, BuilderFortranOrder) {
   EXPECT_EQ(sel[0][1], 1);
   EXPECT_EQ(sel[0][2], 2);
 }
+
+TEST(SelectionTests, TestSelectionMove) {
+  auto base = SelectionBuilder()
+                  .Add({0, 1, 2})
+                  .Add(std::vector<long>{1, 2, 3, 4})
+                  .Order('F')
+                  .Build();
+
+  auto sel = std::move(base);
+  EXPECT_EQ(sel.nIndices(), 2);
+  EXPECT_EQ(sel.Size(), 2);
+
+  EXPECT_EQ(sel[1].size(), 4);
+  EXPECT_EQ(sel[1][0], 1);
+  EXPECT_EQ(sel[1][1], 2);
+  EXPECT_EQ(sel[1][2], 3);
+  EXPECT_EQ(sel[1][3], 4);
+
+  EXPECT_EQ(sel[0].size(), 3);
+  EXPECT_EQ(sel[0][0], 0);
+  EXPECT_EQ(sel[0][1], 1);
+  EXPECT_EQ(sel[0][2], 2);
+}


### PR DESCRIPTION
This PR reworks some of the logic related to 

1. deriving result shapes from columns or data in the case of reads
2. setting column rows shapes in the case of writes
3. fixes an outstanding bug for reasoning about row shapes for variably shaped data in the Data Partitioning process

More specifically it:

- Separates out the logic for reading data from a column vs reading data from a column into a supplied result array.
  -  In the first case, the result shape is derived from the shape of the selected data within the column
  - In the second case the result shape is derived from the shape of the supplied result array.
- By doing so, it is possible to support missing column rows when the result array is supplied by the user.
- In the case of writes fixes setting the row shape of missing rows with the memory index, rather than the raw row index.
- In the Data Partitioning process, more correctly associates memory indices with the shapes of the result array, rather than the raw index