### PR TITLE
Defer to ColumnDesc.ndim if inference from row shapes fails

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,9 @@ History
 
 0.3.2 (DD-MM-2025)
 ------------------
+* Address tar.extractall filter warning (:pr:`179`)
+* Represent scalar column shapes as an array of uint8's composed of 1s (:pr:`179`)
+* Defer to ColumnDesc.ndim if inference from row shapes fails for variably shaped columns (:pr:`179`)
 * Run C++ test suite on macos (:pr:`178`)
 * Default arrow allocation alignment if type size is not a power of 2 (:pr:`176`, :pr:`177`)
 * Support missing column rows when result arrays are supplied during reads (:pr:`174`)

--- a/cpp/arcae/result_shape.cc
+++ b/cpp/arcae/result_shape.cc
@@ -657,10 +657,12 @@ Result<ResultShapeData> ResultShapeData::MakeRead(const TableColumn& column,
   // has already done this
   if (shapes_equal && fixed_shape && missing_rows == 0) {
     fixed_shape->append(IPosition({nselrow}));
-    auto ndim = int(fixed_shape->size());
+    ndim = int(fixed_shape->size());
     return ResultShapeData{column_name, std::move(fixed_shape), ndim, std::move(dtype),
                            std::nullopt};
   }
+
+  if (ndim == -1) ndim = column_desc.ndim();
 
   // Shapes and their rank may vary per row and rows may be missing
   return ResultShapeData{column_name, std::nullopt, ndim, std::move(dtype),

--- a/cpp/arcae/result_shape.cc
+++ b/cpp/arcae/result_shape.cc
@@ -421,7 +421,14 @@ Result<std::shared_ptr<arrow::Array>> ResultShapeData::GetShapeArray() const noe
   --ndim;  // without row
   auto nrow = nRows();
 
-  if (ndim == 0) return std::make_shared<arrow::NullArray>(std::int64_t(nrow));
+  if (ndim == 0) {
+    auto shape_builder = arrow::UInt8Builder();
+    ARROW_RETURN_NOT_OK(shape_builder.Reserve(nrow));
+    for (std::size_t i = 0; i < nrow; ++i) {
+      ARROW_RETURN_NOT_OK(shape_builder.Append(0));
+    }
+    return shape_builder.Finish();
+  }
 
   auto builders = std::vector<arrow::Int32Builder>(ndim);
   auto shape_data_builder = arrow::Int32Builder();
@@ -617,7 +624,13 @@ Result<ResultShapeData> ResultShapeData::MakeRead(const TableColumn& column,
                            std::move(dtype), std::nullopt};
   }
 
-  // Get shapes of each row in the selection
+  // Variably shaped case
+  // Get shapes of each row in the selection and try to infer the
+  // shapes and dimensionality from this data.
+  // We prefer this instead of trusting ColumnDesc.ndim()
+  // because the column may be configured for varying dimensionality/rank,
+  // even though the actual row shapes may have the same dimensionality.
+  // (which we would like to handle. I'm looking at you wsclean MODEL_DATA columns)
   ARROW_ASSIGN_OR_RAISE(auto shapes, MakeRowData(column, selection, allow_missing_rows));
 
   auto missing_rows =
@@ -662,8 +675,14 @@ Result<ResultShapeData> ResultShapeData::MakeRead(const TableColumn& column,
                            std::nullopt};
   }
 
-  if (ndim == -1) ndim = column_desc.ndim();
+  // If it wasn't possible to derive the dimensionality
+  // from the row shapes we now defer to the column descriptor
+  if (ndim == -1) {
+    ndim = column_desc.ndim();
+    if (ndim >= 0) ++ndim;
+  }
 
+  // The most general case:
   // Shapes and their rank may vary per row and rows may be missing
   return ResultShapeData{column_name, std::nullopt, ndim, std::move(dtype),
                          std::move(shapes)};

--- a/cpp/arcae/result_shape.cc
+++ b/cpp/arcae/result_shape.cc
@@ -425,7 +425,7 @@ Result<std::shared_ptr<arrow::Array>> ResultShapeData::GetShapeArray() const noe
     auto shape_builder = arrow::UInt8Builder();
     ARROW_RETURN_NOT_OK(shape_builder.Reserve(nrow));
     for (std::size_t i = 0; i < nrow; ++i) {
-      ARROW_RETURN_NOT_OK(shape_builder.Append(0));
+      ARROW_RETURN_NOT_OK(shape_builder.Append(1));
     }
     return shape_builder.Finish();
   }

--- a/cpp/tests/new_table_proxy_test.cc
+++ b/cpp/tests/new_table_proxy_test.cc
@@ -904,8 +904,13 @@ TEST_F(VariableProxyTest, NegativeSelection) {
 TEST_F(VariableProxyTest, MissingSelection) {
   ASSERT_OK_AND_ASSIGN(auto ntp, OpenTable());
 
+  ASSERT_OK_AND_ASSIGN(auto empty_shapes, ntp->GetRowShapes("VAR_SPARSE_DATA"));
+  auto fsl = std::dynamic_pointer_cast<arrow::FixedSizeListArray>(empty_shapes);
+  EXPECT_TRUE(fsl);
   // The column is completely empty
-  ASSERT_NOT_OK(ntp->GetRowShapes("VAR_SPARSE_DATA"));
+  EXPECT_EQ(fsl->length(), fsl->null_count());
+  // ndim == 2
+  EXPECT_EQ(fsl->list_type()->list_size(), 2);
 
   // Derive minimum viable dimension size.
   casacore::IPosition min_shape(kNDim, std::numeric_limits<ssize_t>::max());

--- a/src/arcae/tests/conftest.py
+++ b/src/arcae/tests/conftest.py
@@ -74,7 +74,7 @@ def tau_ms(tau_ms_tar, tmp_path_factory):
     msdir = tmp_path_factory.mktemp("tau-ms")
 
     with tarfile.open(tau_ms_tar) as tar:
-        tar.extractall(msdir)
+        tar.extractall(msdir, filter="data")
 
     return str(msdir / TAU_MS)
 

--- a/src/arcae/tests/test_pytable.py
+++ b/src/arcae/tests/test_pytable.py
@@ -171,13 +171,15 @@ def test_column_cases(column_case_table):
 def test_row_shapes(column_case_table):
     table = arcae.table(column_case_table)
 
-    assert isinstance(table.row_shapes("SCALAR"), pa.NullArray)
-    assert table.row_shapes("SCALAR").to_pylist() == [None, None, None]
+    assert isinstance(table.row_shapes("SCALAR"), pa.UInt8Array)
+    assert table.row_shapes("SCALAR").to_pylist() == [0, 0, 0]
 
+    assert isinstance(table.row_shapes("VARIABLE"), pa.FixedSizeListArray)
     assert table.row_shapes("VARIABLE").to_pylist() == [[3, 1, 2], [3, 2, 2], [3, 3, 2]]
     assert table.row_shapes("VARIABLE", ([1, 2],)).to_pylist() == [[3, 2, 2], [3, 3, 2]]
     assert table.row_shapes("VARIABLE", ([0],)).to_pylist() == [[3, 1, 2]]
 
+    assert isinstance(table.row_shapes("FIXED"), pa.FixedSizeListArray)
     assert table.row_shapes("FIXED").to_pylist() == [[2, 4], [2, 4], [2, 4]]
     assert table.row_shapes("FIXED", ([1, 2],)).to_pylist() == [[2, 4], [2, 4]]
     assert table.row_shapes("FIXED", ([0],)).to_pylist() == [[2, 4]]

--- a/src/arcae/tests/test_pytable.py
+++ b/src/arcae/tests/test_pytable.py
@@ -172,7 +172,7 @@ def test_row_shapes(column_case_table):
     table = arcae.table(column_case_table)
 
     assert isinstance(table.row_shapes("SCALAR"), pa.UInt8Array)
-    assert table.row_shapes("SCALAR").to_pylist() == [0, 0, 0]
+    assert table.row_shapes("SCALAR").to_pylist() == [1, 1, 1]
 
     assert isinstance(table.row_shapes("VARIABLE"), pa.FixedSizeListArray)
     assert table.row_shapes("VARIABLE").to_pylist() == [[3, 1, 2], [3, 2, 2], [3, 3, 2]]


### PR DESCRIPTION
If it is not possible to infer the column dimensionality from the selection row shapes, fall back to the column descriptor ndim method.

This is so that it is possible to always return shape  and dimensionality information if available (i.e. if column rank varies (ndim == -1))

Also modify GetShapeArray() to return a uint8 array of 1s to represent the shape of scalar arrays. Multidimensional arrays are still represented by a fixed_size_list_array<uint32>(n);