### PR TITLE
Update multithreaded benchmark tests to use the newer API

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,10 @@
 History
 =======
 
+X.Y.Z (DD-MM-YYYY)
+------------------
+* Update multithreaded benchmarks to use the newer API (:pr:`181`)
+
 0.3.2 (17-09-2025)
 ------------------
 * Address tar.extractall filter warning (:pr:`179`)

--- a/src/arcae/tests/test_multithreaded_read.py
+++ b/src/arcae/tests/test_multithreaded_read.py
@@ -24,7 +24,7 @@ COMPARE = False
 THREADS = 16
 INSTANCES = THREADS
 STEP = 10
-MS_PARAMS = {"row": 100 * STEP, "chan": 1024, "corr": 4}
+MS_PARAMS = {"row": 10000 * STEP, "chan": 1024, "corr": 4}
 
 
 @pytest.mark.skipif(not pytest_benchmark, reason="pytest-benchmark not installed")

--- a/src/arcae/tests/test_multithreaded_read.py
+++ b/src/arcae/tests/test_multithreaded_read.py
@@ -1,5 +1,4 @@
 import concurrent.futures as cf
-import threading
 
 import numpy as np
 import pytest
@@ -12,11 +11,9 @@ try:
 except ImportError:
     pytest_benchmark = None
 
-# This test suite benchmarks reads in two cases:
+# This test suite benchmarks reads for the following case:
 #
 # 1. Multiple read requests issued from multiple threads through a single table object
-# 2. Multiple read requests issued from multiple threads through multiple table objects
-#    that have all opened the same file
 #
 # Notes:
 # * COMPARE should be set to False when testing pure I/O, but is useful for
@@ -24,7 +21,8 @@ except ImportError:
 # * Larger dimension sizes are more representative of real world scenarios
 # * Remember to drop caches between tests
 COMPARE = False
-THREADS = 8
+THREADS = 16
+INSTANCES = THREADS
 STEP = 10
 MS_PARAMS = {"row": 100 * STEP, "chan": 1024, "corr": 4}
 
@@ -38,15 +36,15 @@ MS_PARAMS = {"row": 100 * STEP, "chan": 1024, "corr": 4}
 )
 def test_singlefile_multithread_read(ramp_ms, benchmark):
     def read_single(T, startrow, nrow):
-        data = T.getcol("COMPLEX_DATA", startrow=startrow, nrow=nrow)
+        data = T.getcol("COMPLEX_DATA", index=(slice(startrow, startrow + nrow),))
         if COMPARE:
             expected = np.arange(startrow, startrow + nrow)[:, None, None]
             assert_array_equal(data, np.broadcast_to(expected, data.shape))
 
-    def test_():
+    def test_(pool):
         futures = []
 
-        with arcae.table(ramp_ms) as T:
+        with arcae.table(ramp_ms, ninstances=INSTANCES, lockoptions="nolock") as T:
             nrow = T.nrow()
 
             for startrow in range(0, nrow, STEP):
@@ -58,50 +56,5 @@ def test_singlefile_multithread_read(ramp_ms, benchmark):
                 future.result()
 
     with cf.ThreadPoolExecutor(THREADS) as pool:
-        benchmark(test_)
-
-
-@pytest.mark.skipif(not pytest_benchmark, reason="pytest-benchmark not installed")
-@pytest.mark.parametrize(
-    "ramp_ms",
-    [MS_PARAMS],
-    indirect=True,
-    ids=lambda c: f"ramp_ms: {','.join(f'{k}={v}' for k, v in c.items())}",
-)
-def test_multifile_multithreaded_read(ramp_ms, benchmark):
-    local = threading.local()
-
-    def read_multiple(ms, startrow, nrow):
-        try:
-            table_cache = local.table_cache
-        except AttributeError:
-            table_cache = local.table_cache = {}
-
-        try:
-            T = table_cache[ms]
-        except KeyError:
-            print(f"Opening {ms} in thread {threading.get_ident()}")
-            T = table_cache[ms] = arcae.table(ms)
-
-        # with arcae.table(ms) as T:
-        data = T.getcol("COMPLEX_DATA", startrow=startrow, nrow=nrow)
-        if COMPARE:
-            expected = np.arange(startrow, startrow + nrow)[:, None, None]
-            assert_array_equal(data, np.broadcast_to(expected, data.shape))
-
-    def test_(nrow):
-        futures = []
-
-        for startrow in range(0, nrow, STEP):
-            lnrow = min(STEP, nrow - startrow)
-            future = pool.submit(read_multiple, ramp_ms, startrow, lnrow)
-            futures.append(future)
-
-        for future in cf.as_completed(futures):
-            future.result()
-
-    with cf.ThreadPoolExecutor(THREADS) as pool:
-        with arcae.table(ramp_ms) as T:
-            nrow = T.nrow()
-
-        benchmark(test_, nrow)
+        print("Benchmarking starts")
+        benchmark(test_, pool)


### PR DESCRIPTION
The multi-threaded read benchmarks were out of date.

In particular they were built before multiplexing requests over multiple Table instances was built into arcae.

This PR updates the benchmarks to open the table with the `ninstances` and `lockoptions='nolock'` arguments.

It also removes the benchmark where multiple arcae table objects were created and reads were multiplexed at the Python level. This benchmark is redundant as arcae now does this in the C++ layer.

