### PR TITLE
Pin pyarrow==23.0.1 in c++ test cases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
           sudo apt -y update
           sudo apt -y install build-essential cmake
           python -m pip install -U pip
-          python -m pip install pyarrow
+          python -m pip install pyarrow==23.0.1
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v6.0.0
@@ -110,7 +110,7 @@ jobs:
           brew install ninja
           brew reinstall gcc  # Needed for gfortran
           python -m pip install -U pip
-          python -m pip install pyarrow
+          python -m pip install pyarrow==23.0.1
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v6.0.0

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,10 @@
 History
 =======
 
+X.Y.Z (DD-MM-YYYY)
+------------------
+* Pin pyarrow to 23.0.1 in C++ test cases (:pr:`204`)
+
 0.5.1 (02-03-2026)
 ------------------
 * Add an ``arcae.safe_multithreaded_writes`` function indicating whether writing


### PR DESCRIPTION
Apache arrow 24.0.0 was released 

- https://arrow.apache.org/blog/2026/04/21/24.0.0-release/

A warning resulted in failure during compilation of the C++ test cases due to the -Werror compilation flag.

- https://github.com/ratt-ru/arcae/actions/runs/24815424052

This PR pins pyarrow to 23.0.1 in the c++ test case