### PR TITLE
Split PYARROW_LIBDIRS into a list before passing to target_link_directories

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 X.Y.Z (DD-MM-YYYY)
 ------------------
+* Split PYARROW_LIBDIRS into a list before passing to target_link_directories (:pr:`209`)
 * Pin pyarrow to 23.0.1 in C++ test cases (:pr:`204`)
 
 0.5.1 (02-03-2026)

--- a/src/arcae/lib/CMakeLists.txt
+++ b/src/arcae/lib/CMakeLists.txt
@@ -18,7 +18,8 @@ add_custom_command(
 python_add_library(arrow_tables MODULE WITH_SOABI arrow_tables.cc)
 
 target_link_libraries(arrow_tables PUBLIC arcae PkgConfig::casacore)
-target_link_directories(arrow_tables PUBLIC ${PYARROW_LIBDIRS})
+string(REPLACE " " ";" _PYARROW_LIBDIRS ${PYARROW_LIBDIRS})
+target_link_directories(arrow_tables PUBLIC ${_PYARROW_LIBDIRS})
 target_include_directories(arrow_tables PUBLIC
                             PkgConfig::casacore
                             absl::span


### PR DESCRIPTION
Split PYARROW_LIBDIRS into a CMake list before passing to target_link_directories

CMake's target_link_directories expects a semicolon-separated list, but PYARROW_LIBDIRS may arrive as a space-separated string. The string(REPLACE) converts it to the expected list format so all directories are passed correctly.