### PR TITLE
Split PYARROW_LIBDIRS into a list before passing to target_link_directories

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,7 +4,7 @@ History
 
 X.Y.Z (DD-MM-YYYY)
 ------------------
-* Split PYARROW_LIBDIRS into a list before passing to target_link_directories (:pr:`209`)
+* Split PYARROW_LIBDIRS into a list before passing to target_link_directories (:pr:`209`, :pr:`210`)
 * Pin pyarrow to 23.0.1 in C++ test cases (:pr:`204`)
 
 0.5.1 (02-03-2026)

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -19,7 +19,8 @@ add_library(arcae SHARED
 target_compile_options(arcae PRIVATE
     $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:
         -Wall -Werror -pedantic>)
-target_link_directories(arcae PUBLIC ${PYARROW_LIBDIRS})
+string(REPLACE " " ";" _PYARROW_LIBDIRS "${PYARROW_LIBDIRS}")
+target_link_directories(arcae PUBLIC ${_PYARROW_LIBDIRS})
 target_link_libraries(arcae PkgConfig::casacore arrow absl::span)
 target_include_directories(arcae PUBLIC PkgConfig::casacore absl::span ${PYARROW_INCLUDE} ${CMAKE_INCLUDE_CURRENT_DIR})
 


### PR DESCRIPTION
- Related to #209 