### PR TITLE
Introduce `pytest != 9.1.0` version restriction

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,10 @@
 History
 =======
 
+X.Y.Z (DD-MM-YYYY)
+------------------
+* Restrict pytest to ``< 9.0.0`` (:pr:`214`)
+
 0.5.2 (12-06-2026)
 ------------------
 * Build arcae as a static library with minimal symbol exports (:pr:`211`, :pr:`212`)

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,7 +4,7 @@ History
 
 X.Y.Z (DD-MM-YYYY)
 ------------------
-* Restrict pytest to ``< 9.0.0`` (:pr:`214`)
+* Introduce ``pytest != 9.1.0`` version restriction (:pr:`214`)
 
 0.5.2 (12-06-2026)
 ------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dev = [
 test = [
     "duckdb",
     "platformdirs",
-    "pytest >= 7.0.0, <9.0.0",
+    "pytest >= 7.0.0, !=9.1.0",
     "python-casacore >= 3.5.0; sys_platform == 'linux' and platform_machine == 'x86_64' and python_version<'3.14'",
     "requests"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dev = [
 test = [
     "duckdb",
     "platformdirs",
-    "pytest >= 7.0.0",
+    "pytest >= 7.0.0, <9.0.0",
     "python-casacore >= 3.5.0; sys_platform == 'linux' and platform_machine == 'x86_64' and python_version<'3.14'",
     "requests"
 ]


### PR DESCRIPTION
9.1.0 introduced the following regression

- https://github.com/pytest-dev/pytest/issues/14591