### PR TITLE
Update to casacore 3.8.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,9 +106,11 @@ jobs:
 
       - name: Install C++ Compiler and cmake
         run: |
-          brew update
-          brew install ninja
-          brew reinstall gcc  # Needed for gfortran
+          bash ci/scripts/before-all-macos.sh
+          # casacore >= 3.8 needs bison >= 3; macOS ships system bison 2.3.
+          # Homebrew bison/flex are keg-only, so prepend them to PATH.
+          echo "$(brew --prefix bison)/bin" >> "$GITHUB_PATH"
+          echo "$(brew --prefix flex)/bin" >> "$GITHUB_PATH"
           python -m pip install -U pip
           python -m pip install pyarrow==23.0.1
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 X.Y.Z (DD-MM-YYYY)
 ------------------
+* Upgrade to casacore 3.8.1 (:pr:`218`)
 * Remove extraneous whitespace in casacore patch (:pr:`215`)
 * Introduce ``pytest != 9.1.0`` version restriction (:pr:`214`)
 

--- a/ci/scripts/before-all-macos.sh
+++ b/ci/scripts/before-all-macos.sh
@@ -1,6 +1,7 @@
 set -ex
 
-brew install python llvm
+brew update
+brew install bison flex ninja python llvm
 brew reinstall gcc  # Need for gfortran
 curl "https://awscli.amazonaws.com/AWSCLIV2.pkg" -o "AWSCLIV2.pkg"
 sudo installer -pkg AWSCLIV2.pkg -target /

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -38,23 +38,31 @@ endif()
 
 # casa_scimath_f is a Fortran archive whose objects reference the gfortran
 # runtime (_gfortran_*), but the static casacore CONFIG targets don't propagate
-# it through their link interface. The Python extension is a shared library, so
-# Linux tolerates the unresolved symbols at link time; the fully-linked C++ test
-# executables do not. Discover the Fortran implicit link libraries and add them
-# to arcae's link interface. Guarded by check_language so machines without a
-# Fortran compiler (which don't need one, since casacore is prebuilt by vcpkg)
-# still configure.
+# it through their link interface. Only the fully-linked C++ test executables
+# need this resolved: the Python extension is a shared module whose Fortran-
+# calling code paths are never exercised at import, so it links (and imports)
+# fine with the symbols left undefined. We therefore expose the Fortran runtime
+# to the tests subdirectory (see cpp/tests/CMakeLists.txt) rather than putting
+# it on arcae's PUBLIC interface, which would drag the gcc runtime (emutls_w,
+# gfortran, quadmath, ...) into the module too. Guarded by check_language so
+# machines without a Fortran compiler (which don't need one, since casacore is
+# prebuilt by vcpkg) still configure.
 include(CheckLanguage)
 check_language(Fortran)
 if(CMAKE_Fortran_COMPILER)
     enable_language(Fortran)
+    # Both the libraries AND their directories are needed: on macOS the gcc
+    # runtime (libemutls_w.a etc.) lives in Homebrew's keg-only path, which the
+    # clang linker doesn't search by default.
     set(FORTRAN_RUNTIME_LIBS ${CMAKE_Fortran_IMPLICIT_LINK_LIBRARIES})
+    set(FORTRAN_RUNTIME_DIRS ${CMAKE_Fortran_IMPLICIT_LINK_DIRECTORIES})
 else()
     message(WARNING
         "No Fortran compiler found; the gfortran runtime will not be added to "
-        "the link interface. Linking the C++ test executables may fail with "
-        "undefined _gfortran_* references.")
+        "the C++ test executables' link. Linking them may fail with undefined "
+        "_gfortran_* references.")
     set(FORTRAN_RUNTIME_LIBS "")
+    set(FORTRAN_RUNTIME_DIRS "")
 endif()
 
 add_library(arcae STATIC
@@ -77,7 +85,7 @@ target_compile_options(arcae PRIVATE
     -fvisibility=hidden -fvisibility-inlines-hidden)
 string(REPLACE " " ";" _PYARROW_LIBDIRS "${PYARROW_LIBDIRS}")
 target_link_directories(arcae PUBLIC ${_PYARROW_LIBDIRS})
-target_link_libraries(arcae PUBLIC arrow absl::span "${CASACORE_LINK_GROUP}" ${FORTRAN_RUNTIME_LIBS})
+target_link_libraries(arcae PUBLIC arrow absl::span "${CASACORE_LINK_GROUP}")
 target_include_directories(arcae PUBLIC
     ${CASACORE_PC_INCLUDE_DIRS}
     ${PYARROW_INCLUDE}

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -36,6 +36,27 @@ else()
     set(CASACORE_LINK_GROUP "$<LINK_GROUP:RESCAN,${_casa_group}>")
 endif()
 
+# casa_scimath_f is a Fortran archive whose objects reference the gfortran
+# runtime (_gfortran_*), but the static casacore CONFIG targets don't propagate
+# it through their link interface. The Python extension is a shared library, so
+# Linux tolerates the unresolved symbols at link time; the fully-linked C++ test
+# executables do not. Discover the Fortran implicit link libraries and add them
+# to arcae's link interface. Guarded by check_language so machines without a
+# Fortran compiler (which don't need one, since casacore is prebuilt by vcpkg)
+# still configure.
+include(CheckLanguage)
+check_language(Fortran)
+if(CMAKE_Fortran_COMPILER)
+    enable_language(Fortran)
+    set(FORTRAN_RUNTIME_LIBS ${CMAKE_Fortran_IMPLICIT_LINK_LIBRARIES})
+else()
+    message(WARNING
+        "No Fortran compiler found; the gfortran runtime will not be added to "
+        "the link interface. Linking the C++ test executables may fail with "
+        "undefined _gfortran_* references.")
+    set(FORTRAN_RUNTIME_LIBS "")
+endif()
+
 add_library(arcae STATIC
     arcae/configuration.cc
     arcae/descriptor.cc
@@ -56,7 +77,7 @@ target_compile_options(arcae PRIVATE
     -fvisibility=hidden -fvisibility-inlines-hidden)
 string(REPLACE " " ";" _PYARROW_LIBDIRS "${PYARROW_LIBDIRS}")
 target_link_directories(arcae PUBLIC ${_PYARROW_LIBDIRS})
-target_link_libraries(arcae PUBLIC arrow absl::span "${CASACORE_LINK_GROUP}")
+target_link_libraries(arcae PUBLIC arrow absl::span "${CASACORE_LINK_GROUP}" ${FORTRAN_RUNTIME_LIBS})
 target_include_directories(arcae PUBLIC
     ${CASACORE_PC_INCLUDE_DIRS}
     ${PYARROW_INCLUDE}

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -5,6 +5,13 @@ add_library(test_utils test_utils.cc)
 add_compile_options("-fsanitize=address")
 add_link_options("-fsanitize=address")
 
+# The gtest executables link casacore's static archives fully, so they need the
+# gfortran runtime that casa_scimath_f references (see cpp/CMakeLists.txt).
+# Attach it PUBLICLY to test_utils, which every test links after arcae/casacore,
+# so the runtime appears late enough on the link line to resolve the symbols.
+target_link_directories(test_utils PUBLIC ${FORTRAN_RUNTIME_DIRS})
+target_link_libraries(test_utils PUBLIC ${FORTRAN_RUNTIME_LIBS})
+
 
 add_executable(result_shape_test result_shape_test.cc)
 target_link_libraries(result_shape_test PRIVATE GTest::gtest_main arcae test_utils)

--- a/vcpkg/overlay-ports/casacore/001-casacore-cmake.patch
+++ b/vcpkg/overlay-ports/casacore/001-casacore-cmake.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 62c3404..8f151f2 100644
+index 7401224..97388fd 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -354,11 +354,6 @@ endif (_usebison STREQUAL YES)
+@@ -361,11 +361,6 @@ endif (_usebison STREQUAL YES)
  if (_uselapack STREQUAL YES)
      find_package (BLAS REQUIRED)
      find_package (LAPACK REQUIRED)
@@ -14,17 +14,17 @@ index 62c3404..8f151f2 100644
  endif (_uselapack STREQUAL YES)
  if (_usefits STREQUAL YES)
      find_package (CFITSIO 3.030 REQUIRED) # Should pad to three decimal digits
-@@ -400,11 +395,15 @@ if (HDF5_FOUND)
+@@ -410,11 +405,15 @@ if (HDF5_FOUND)
      add_definitions(-DHAVE_HDF5)
  endif (HDF5_FOUND)
  
--include_directories (${FFTW3_INCLUDE_DIRS})
+-include_directories (SYSTEM ${FFTW3_INCLUDE_DIRS})
 -add_definitions(-DHAVE_FFTW3)
 -if (NOT FFTW3_DISABLE_THREADS)
 -    add_definitions(-DHAVE_FFTW3_THREADS)
 -endif (NOT FFTW3_DISABLE_THREADS)
 +if (BUILD_FFTW3)
-+    include_directories (${FFTW3_INCLUDE_DIRS})
++    include_directories (SYSTEM ${FFTW3_INCLUDE_DIRS})
 +    add_definitions(-DHAVE_FFTW3)
 +    if (NOT FFTW3_DISABLE_THREADS)
 +        add_definitions(-DHAVE_FFTW3_THREADS)
@@ -35,7 +35,7 @@ index 62c3404..8f151f2 100644
  
  if (DL_FOUND)
      add_definitions(-DHAVE_DL)
-@@ -557,8 +556,41 @@ endforeach (module)
+@@ -567,8 +566,41 @@ endforeach (module)
  
  # Install pkg-config support file
  CONFIGURE_FILE("casacore.pc.in" "casacore.pc" @ONLY)
@@ -91,20 +91,21 @@ index 0000000..8c9ad12
 +
 +check_required_components(@PROJECT_NAME@)
 diff --git a/casa/CMakeLists.txt b/casa/CMakeLists.txt
-index 950752c..d4c35cb 100644
+index 60fa2b6..a573d61 100644
 --- a/casa/CMakeLists.txt
 +++ b/casa/CMakeLists.txt
 @@ -15,7 +15,9 @@ set (
  parser_inputs
  JsonGram
  )
-  
+- 
++
 +find_package(ZLIB REQUIRED)
 +
  foreach (src ${parser_inputs})
      if (BISON_VERSION VERSION_LESS 3.0)
-         BISON_TARGET (${src} Json/${src}.yy ${CMAKE_CURRENT_BINARY_DIR}/${src}.ycc COMPILE_FLAGS "-y -p ${src}")
-@@ -291,16 +293,18 @@ find_library(libm m)
+         set(EXTRA_BISON_FLAGS "-p ${src}")
+@@ -294,16 +296,18 @@ find_library(libm m)
  
  target_link_libraries (
  casa_casa
@@ -139,7 +140,7 @@ index 12229f9..a15e508 100644
  
  // <summary>Base class for all Casacore library errors</summary>
 diff --git a/casa/Json/JsonOut.h b/casa/Json/JsonOut.h
-index b5229c5..66596d2 100644
+index b5229c5..7250d93 100644
 --- a/casa/Json/JsonOut.h
 +++ b/casa/Json/JsonOut.h
 @@ -174,6 +174,10 @@ namespace casacore { //# NAMESPACE CASACORE - BEGIN
@@ -246,10 +247,10 @@ index b2e4220..45dde2e 100644
 +target_link_libraries (fits2table PUBLIC casa_fits ${CASACORE_ARCH_LIBS} PRIVATE ZLIB::ZLIB)
  install(TARGETS fits2table)
 diff --git a/images/CMakeLists.txt b/images/CMakeLists.txt
-index 20f5d0a..39db9bd 100644
+index 5ff84c3..4602bb1 100644
 --- a/images/CMakeLists.txt
 +++ b/images/CMakeLists.txt
-@@ -78,10 +78,11 @@ casa_lattices
+@@ -83,10 +83,11 @@ casa_lattices
  ${CASACORE_ARCH_LIBS}
  )
  
@@ -287,7 +288,7 @@ index a2c9d56..d3b5b65 100644
  LIBRARY DESTINATION lib${LIB_SUFFIX}
  ARCHIVE DESTINATION lib${LIB_SUFFIX}
 diff --git a/measures/CMakeLists.txt b/measures/CMakeLists.txt
-index 6b2e42b..a6dc175 100644
+index 91285e3..696a859 100644
 --- a/measures/CMakeLists.txt
 +++ b/measures/CMakeLists.txt
 @@ -78,10 +78,11 @@ init_pch_support(casa_measures ${top_level_headers})
@@ -304,10 +305,10 @@ index 6b2e42b..a6dc175 100644
  ARCHIVE DESTINATION lib${LIB_SUFFIX}
  LIBRARY PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
 diff --git a/mirlib/CMakeLists.txt b/mirlib/CMakeLists.txt
-index 0703a5d..46f2684 100644
+index b8b6aac..0b71077 100644
 --- a/mirlib/CMakeLists.txt
 +++ b/mirlib/CMakeLists.txt
-@@ -22,6 +22,7 @@ target_link_libraries (casa_mirlib casa_casa ${CASACORE_ARCH_LIBS})
+@@ -27,6 +27,7 @@ target_link_libraries (casa_mirlib casa_casa ${CASACORE_ARCH_LIBS})
  
  install (
  TARGETS casa_mirlib
@@ -316,10 +317,10 @@ index 0703a5d..46f2684 100644
  LIBRARY DESTINATION lib${LIB_SUFFIX}
  ARCHIVE DESTINATION lib${LIB_SUFFIX}
 diff --git a/ms/CMakeLists.txt b/ms/CMakeLists.txt
-index 5602283..ee08a8d 100644
+index 850ab87..9ba0db0 100644
 --- a/ms/CMakeLists.txt
 +++ b/ms/CMakeLists.txt
-@@ -173,9 +173,10 @@ casa_ms casa_measures
+@@ -189,9 +189,10 @@ casa_ms casa_measures
  ${CASACORE_ARCH_LIBS}
  )
  
@@ -364,54 +365,6 @@ index b8340e0..6b434d3 100644
  LIBRARY DESTINATION lib${LIB_SUFFIX}
  ARCHIVE DESTINATION lib${LIB_SUFFIX}
  LIBRARY PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
-diff --git a/python/CMakeLists-cmake3.14.txt b/python/CMakeLists-cmake3.14.txt
-index 7c981f7..1ce6b4d 100644
---- a/python/CMakeLists-cmake3.14.txt
-+++ b/python/CMakeLists-cmake3.14.txt
-@@ -63,6 +63,7 @@ Converters/PycArray.tcc
- target_link_libraries (casa_python casa_casa ${PYTHON2_Boost_LIBRARIES} ${PYTHON2_LIBRARIES} ${CASACORE_ARCH_LIBS})
- 
- install (TARGETS casa_python
-+EXPORT casacore
- RUNTIME DESTINATION bin
- LIBRARY DESTINATION lib${LIB_SUFFIX}
- ARCHIVE DESTINATION lib${LIB_SUFFIX}
-diff --git a/python/CMakeLists-older-cmake.txt b/python/CMakeLists-older-cmake.txt
-index 96411e7..e145da3 100644
---- a/python/CMakeLists-older-cmake.txt
-+++ b/python/CMakeLists-older-cmake.txt
-@@ -90,6 +90,7 @@ Converters/PycArray.tcc
- target_link_libraries (casa_python casa_casa ${PYTHON2_Boost_LIBRARIES} ${PYTHON2_LIBRARIES} ${CASACORE_ARCH_LIBS})
- 
- install (TARGETS casa_python
-+EXPORT casacore
- RUNTIME DESTINATION bin
- LIBRARY DESTINATION lib${LIB_SUFFIX}
- ARCHIVE DESTINATION lib${LIB_SUFFIX}
-diff --git a/python3/CMakeLists-cmake3.14.txt b/python3/CMakeLists-cmake3.14.txt
-index 921c4c3..e5746d1 100644
---- a/python3/CMakeLists-cmake3.14.txt
-+++ b/python3/CMakeLists-cmake3.14.txt
-@@ -54,6 +54,7 @@ add_library (casa_python3
- target_link_libraries (casa_python3 casa_casa ${PYTHON3_Boost_LIBRARIES} ${PYTHON3_LIBRARIES})
- 
- install (TARGETS casa_python3
-+EXPORT casacore
- RUNTIME DESTINATION bin
- LIBRARY DESTINATION lib${LIB_SUFFIX}
- ARCHIVE DESTINATION lib${LIB_SUFFIX}
-diff --git a/python3/CMakeLists-older-cmake.txt b/python3/CMakeLists-older-cmake.txt
-index 8a42cc9..5fe0999 100644
---- a/python3/CMakeLists-older-cmake.txt
-+++ b/python3/CMakeLists-older-cmake.txt
-@@ -84,6 +84,7 @@ add_library (casa_python3
- target_link_libraries (casa_python3 casa_casa ${PYTHON3_Boost_LIBRARIES} ${PYTHON3_LIBRARIES})
- 
- install (TARGETS casa_python3
-+EXPORT casacore
- RUNTIME DESTINATION bin
- LIBRARY DESTINATION lib${LIB_SUFFIX}
- ARCHIVE DESTINATION lib${LIB_SUFFIX}
 diff --git a/scimath/CMakeLists.txt b/scimath/CMakeLists.txt
 index b7f2900..9999811 100644
 --- a/scimath/CMakeLists.txt
@@ -437,10 +390,10 @@ index 69bd4d7..8e6aa8d 100644
  ARCHIVE DESTINATION lib${LIB_SUFFIX}
  LIBRARY PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
 diff --git a/tables/CMakeLists.txt b/tables/CMakeLists.txt
-index 31cf243..611f89a 100644
+index 59feaec..cd87055 100644
 --- a/tables/CMakeLists.txt
 +++ b/tables/CMakeLists.txt
-@@ -241,11 +241,18 @@ TaQL.h
+@@ -258,15 +258,22 @@ TaQL.h
  
  init_pch_support(casa_tables ${top_level_headers})
  
@@ -452,6 +405,10 @@ index 31cf243..611f89a 100644
 +    target_link_libraries(casa_tables adios2::adios2)
 +  endif(ADIOS2_FOUND)
 +endif(MPI_FOUND)
+ if(BUILD_SISCO)
+   target_link_libraries (casa_tables ${LibDeflate_LIBRARY})
+   target_include_directories(casa_tables PUBLIC ${LibDeflate_INCLUDE_DIR})
+ endif(BUILD_SISCO)
  
 -add_subdirectory (apps)
 +# apps subdirectory disabled (arcae static monolith build)
@@ -462,7 +419,7 @@ index 31cf243..611f89a 100644
  ARCHIVE DESTINATION lib${LIB_SUFFIX}
  LIBRARY PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
 diff --git a/tables/Tables/PlainTable.cc b/tables/Tables/PlainTable.cc
-index 2a41c4f..fb088a3 100644
+index f8f7653..fe1c079 100644
 --- a/tables/Tables/PlainTable.cc
 +++ b/tables/Tables/PlainTable.cc
 @@ -45,7 +45,7 @@
@@ -475,12 +432,12 @@ index 2a41c4f..fb088a3 100644
  PlainTable::PlainTable (SetupNewTable& newtab, rownr_t nrrow, Bool initialize,
                          const TableLock& lockOptions, int endianFormat,
 diff --git a/tables/Tables/PlainTable.h b/tables/Tables/PlainTable.h
-index 3179d8e..c0a0ee4 100644
+index 5742020..c5c5f8e 100644
 --- a/tables/Tables/PlainTable.h
 +++ b/tables/Tables/PlainTable.h
-@@ -312,7 +312,7 @@ private:
-                                        //# False = little endian canonical
+@@ -316,7 +316,7 @@ private:
      TSMOption      tsmOption_p;
+     Bool           changeTiledDataOnly_; //# Allow updates to data in existing tiled columns
      //# cache of open (plain) tables
 -    static TableCache theirTableCache;
 +    static thread_local TableCache theirTableCache;
@@ -488,7 +445,7 @@ index 3179d8e..c0a0ee4 100644
  
  
 diff --git a/tables/Tables/RefRows.cc b/tables/Tables/RefRows.cc
-index 957b3e1..f80a977 100644
+index 957b3e1..0d57066 100644
 --- a/tables/Tables/RefRows.cc
 +++ b/tables/Tables/RefRows.cc
 @@ -38,17 +38,24 @@ RefRows::RefRows (const Vector<rownr_t>& rowNumbers, Bool isSliced,
@@ -520,7 +477,7 @@ index 957b3e1..f80a977 100644
      if (itsSliced) {
  	AlwaysAssert (itsNrows%3 == 0, AipsError);
 diff --git a/tables/Tables/RefRows.h b/tables/Tables/RefRows.h
-index 32ab695..ef2dff8 100644
+index 32ab695..f1f738e 100644
 --- a/tables/Tables/RefRows.h
 +++ b/tables/Tables/RefRows.h
 @@ -92,6 +92,9 @@ public:
@@ -543,7 +500,7 @@ index 32ab695..ef2dff8 100644
  
      // Fill the itsNrows variable.
 diff --git a/tables/Tables/TableProxy.cc b/tables/Tables/TableProxy.cc
-index f65cf26..75268a5 100644
+index f65cf26..3f806cd 100644
 --- a/tables/Tables/TableProxy.cc
 +++ b/tables/Tables/TableProxy.cc
 @@ -271,6 +271,9 @@ Record TableProxy::lockOptions()
@@ -556,15 +513,6 @@ index f65cf26..75268a5 100644
    default:
      option = "unknown";
    }
-@@ -1172,7 +1175,7 @@ Record TableProxy::getVarColumn (const String& columnName,
-   char namebuf[22];
-   for (Int64 i=0; i<nrows; i++) {
-     // Add the result to the record with field name formed from 1-based rownr.
--    snprintf (namebuf, sizeof(namebuf), "r%lli", row+1);
-+    sprintf (namebuf, "r%lli", row+1);
-     if (tabcol.isDefined(row)) {
-       getValueFromTable(columnName, row, 1, 1, False).toRecord (rec, namebuf);
-     } else {
 @@ -3403,10 +3406,12 @@ TableLock TableProxy::makeLockOptions (const Record& options)
      opt = TableLock::PermanentLocking;
    } else if (str == "permanentwait") {

--- a/vcpkg/overlay-ports/casacore/portfile.cmake
+++ b/vcpkg/overlay-ports/casacore/portfile.cmake
@@ -3,8 +3,8 @@ include(vcpkg_find_fortran)
 vcpkg_from_github(
     OUT_SOURCE_PATH src
     REPO "casacore/casacore"
-    REF "v3.7.1"
-    SHA512 990262f5f64fb84a4af71add715972cf7aa24c09a7acd903a3a8526f482ccba84da1c54dc9d2bf151bfdb824be811a39cdc740852da86c584373183d48a00822
+    REF "v3.8.1"
+    SHA512 41d4463432033995d0e85632faa07c2fedc820a810f593d2aad5144706a41482296200730fc0b99d5ad962b7ffbfb55c0b67a123d0f49f0e8f774cfbd8d9c9f4
     PATCHES
         001-casacore-cmake.patch
 )

--- a/vcpkg/overlay-ports/casacore/portfile.cmake
+++ b/vcpkg/overlay-ports/casacore/portfile.cmake
@@ -55,6 +55,12 @@ vcpkg_cmake_configure(
         -DBUILD_TESTING=OFF
         -DUSE_PCH=OFF
         -DCMAKE_CXX_STANDARD=20
+        # Pass the vcpkg-acquired flex/bison to casacore's own find_package
+        # calls. casacore 3.8 requires bison >= 3; without these, its
+        # find_package(BISON 3) picks up the system bison (e.g. macOS's 2.3)
+        # and configuration fails.
+        -DBISON_EXECUTABLE=${BISON}
+        -DFLEX_EXECUTABLE=${FLEX}
         ${fortran_args}
 )
 

--- a/vcpkg/overlay-ports/casacore/vcpkg.json
+++ b/vcpkg/overlay-ports/casacore/vcpkg.json
@@ -9,6 +9,7 @@
     "cfitsio",
     "gsl",
     "lapack",
+    "libdeflate",
     {
       "name": "openblas",
       "default-features": false

--- a/vcpkg/overlay-ports/casacore/vcpkg.json
+++ b/vcpkg/overlay-ports/casacore/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "casacore",
-  "version": "3.7.1",
+  "version": "3.8.1",
   "description": "The casacore libraries",
   "homepage": "https://casacore.github.io/",
   "supports": "!windows",


### PR DESCRIPTION
Upgrade vendored casacore to 3.8.1

Bump the vcpkg overlay port from casacore v3.7.1 to v3.8.1 (REF, SHA512
and vcpkg.json version) and carry the surrounding build-system changes
the new release requires.

- Rebase 001-casacore-cmake.patch onto 3.8.1: refresh hunk offsets, drop
  the python/python3 EXPORT hunks and the sprintf revert (both now
  obsolete upstream), and pick up the BUILD_SISCO/LibDeflate link block.
- Depend on libdeflate (casacore 3.8's SISCO storage manager) via the
  port's vcpkg.json.
- Handle the new bison >= 3 requirement: install bison/flex in the macOS
  CI scripts (system bison is 2.3, Homebrew's is keg-only) and pass the
  vcpkg-acquired BISON_EXECUTABLE/FLEX_EXECUTABLE into casacore's
  configure so find_package(BISON 3) doesn't pick up the system copy.
- Resolve the gfortran runtime for the C++ gtest executables. casa_scimath_f
  references _gfortran_* symbols that the static casacore targets don't
  propagate, so expose CMAKE_Fortran_IMPLICIT_LINK_{LIBRARIES,DIRECTORIES}
  to the tests subdirectory only (guarded by check_language(Fortran)),
  keeping the gcc runtime off arcae's PUBLIC interface and out of the
  Python extension module.